### PR TITLE
Fix "relaxProperties" deprecation warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,5 @@
 "dependencies": {},
 "homepage": "http://dyaml.alwaysdata.net/",
 "name": "dyaml",
-"copyright": "Copyright © 2011-2013, Ferdinand Majerech",
-"buildRequirements": ["relaxProperties"],
+"copyright": "Copyright © 2011-2013, Ferdinand Majerech"
 }


### PR DESCRIPTION
Build requirement "relaxProperties" is no longer needed, because it is now the default behavior.
