### PR TITLE
add package.d, deprecate yaml/dyaml.all

### DIFF
--- a/source/dyaml/all.d
+++ b/source/dyaml/all.d
@@ -4,15 +4,6 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-module dyaml.all;
+deprecated("Import dyaml instead") module dyaml.all;
 
-public import dyaml.constructor;
-public import dyaml.dumper;
-public import dyaml.encoding;
-public import dyaml.exception;
-public import dyaml.linebreak;
-public import dyaml.loader;
-public import dyaml.representer;
-public import dyaml.resolver;
-public import dyaml.style;
-public import dyaml.node;
+public import dyaml;

--- a/source/dyaml/package.d
+++ b/source/dyaml/package.d
@@ -1,0 +1,17 @@
+//          Copyright Ferdinand Majerech 2011.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+module dyaml;
+
+public import dyaml.constructor;
+public import dyaml.dumper;
+public import dyaml.encoding;
+public import dyaml.exception;
+public import dyaml.linebreak;
+public import dyaml.loader;
+public import dyaml.representer;
+public import dyaml.resolver;
+public import dyaml.style;
+public import dyaml.node;

--- a/source/yaml.d
+++ b/source/yaml.d
@@ -4,15 +4,6 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-module yaml;
+deprecated("Import dyaml instead") module yaml;
 
-public import dyaml.constructor;
-public import dyaml.dumper;
-public import dyaml.encoding;
-public import dyaml.exception;
-public import dyaml.linebreak;
-public import dyaml.loader;
-public import dyaml.representer;
-public import dyaml.resolver;
-public import dyaml.style;
-public import dyaml.node;
+public import dyaml;


### PR DESCRIPTION
Fixes #23.
Note that this breaks compiling on versions of dmd older than 2.064. As that version is 2 years old at this point, this should not be a big issue...
