### PR TITLE
Add Meson build definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,33 @@
-language: d
+dist: trusty
 sudo: false
+
+language: d
+os:
+ - linux
+ #- osx
+d:
+ - dmd
+ - dmd-beta
+ - dmd-nightly
+ - ldc
+ - ldc-beta
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja python3; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install meson; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip3 install meson; fi
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir .ntmp && curl -L https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip -o .ntmp/ninja-linux.zip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then unzip .ntmp/ninja-linux.zip -d .ntmp; fi
+
+before_script:
+  - export PATH=$PATH:$PWD/.ntmp
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then meson build && ninja -C build; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ninja -C build test -v; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) meson build && ninja -C build test; fi
+  - dub build
+  - dub test

--- a/contrib/subprojects/tinyendian.wrap
+++ b/contrib/subprojects/tinyendian.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+directory = tinyendian
+
+url=https://github.com/ximion/tinyendian
+revision=head

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,81 @@
+project('D-YAML', 'd',
+    meson_version: '>=0.40.0',
+    subproject_dir: 'contrib/subprojects'
+)
+
+project_version      = '0.5.4'
+project_soversion    = '0'
+
+src_dir = include_directories('source/')
+pkgc = import('pkgconfig')
+
+dyaml_src = [
+    'source/dyaml/all.d',
+    'source/dyaml/anchor.d',
+    'source/dyaml/composer.d',
+    'source/dyaml/constructor.d',
+    'source/dyaml/dumper.d',
+    'source/dyaml/emitter.d',
+    'source/dyaml/encoding.d',
+    'source/dyaml/escapes.d',
+    'source/dyaml/event.d',
+    'source/dyaml/exception.d',
+    'source/dyaml/fastcharsearch.d',
+    'source/dyaml/flags.d',
+    'source/dyaml/hacks.d',
+    'source/dyaml/linebreak.d',
+    'source/dyaml/loader.d',
+    'source/dyaml/node.d',
+    'source/dyaml/nogcutil.d',
+    'source/dyaml/package.d',
+    'source/dyaml/parser.d',
+    'source/dyaml/queue.d',
+    'source/dyaml/reader.d',
+    'source/dyaml/representer.d',
+    'source/dyaml/resolver.d',
+    'source/dyaml/scanner.d',
+    'source/dyaml/serializer.d',
+    'source/dyaml/stream.d',
+    'source/dyaml/style.d',
+    'source/dyaml/tag.d',
+    'source/dyaml/tagdirective.d',
+    'source/dyaml/testcommon.d',
+    'source/dyaml/testcompare.d',
+    'source/dyaml/testconstructor.d',
+    'source/dyaml/testemitter.d',
+    'source/dyaml/testerrors.d',
+    'source/dyaml/testinputoutput.d',
+    'source/dyaml/testreader.d',
+    'source/dyaml/testrepresenter.d',
+    'source/dyaml/testresolver.d',
+    'source/dyaml/testtokens.d',
+    'source/dyaml/token.d',
+    'source/dyaml/unused.d',
+    'source/dyaml/zerostring.d',
+    'source/yaml.d'
+]
+install_headers('source/yaml.d', subdir: 'd/yaml/')
+install_subdir('source/dyaml', install_dir: 'include/d/yaml/')
+
+tinyendian_dep = dependency('tinyendian', version: '>=0.1.2', required: false)
+if not tinyendian_dep.found()
+    tinyendian_sp = subproject('tinyendian')
+    tinyendian_dep = declare_dependency(link_with: tinyendian_sp.get_variable('tinyendian_lib'),
+        include_directories: tinyendian_sp.get_variable('src_dir')
+    )
+endif
+
+dyaml_lib = library('dyaml',
+        [dyaml_src],
+        include_directories: [src_dir],
+        dependencies: [tinyendian_dep],
+        install: true,
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'dyaml',
+              libraries: dyaml_lib,
+              subdirs: 'd/yaml/',
+              version: project_version,
+              description: 'YAML parser and emitter for the D programming language.'
+)


### PR DESCRIPTION
This adds a Meson build definition for easy packaging and integration with other projects using Meson. I am using this for a while on my own D-YAML for that itself is branched off the Sociomatic D-YAML for at https://github.com/sociomantic-tsunami/D-YAML .

I thought it made sense to push this upstream now that D-YAML is looked for by more people.

For maximum fun, this PR for tinyendian should also be merged: https://github.com/kiith-sa/tinyendian/pull/3 (when that's done, I can adjust the repository path in the wrapfile).
Cheers,
    Matthias
