### PR TITLE
Remove use of the useless debugInfoC mode

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -11,8 +11,8 @@
 
     "buildTypes":
     {
-        "debug": { "buildOptions": ["debugMode", "debugInfoC"] },
+        "debug": { "buildOptions": ["debugMode"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline", "noBoundsCheck"] },
-        "profile": { "buildOptions": ["releaseMode", "optimize", "noBoundsCheck", "debugInfoC"] },
+        "profile": { "buildOptions": ["releaseMode", "optimize", "noBoundsCheck"] },
     },
 }


### PR DESCRIPTION
See also https://github.com/dlang/dmd/pull/7815 and https://github.com/dlang/dub/pull/1361

tl;dr: `debugInfoC` translates to the `-gc` which is an deprecated alias for to `-g`.