### PR TITLE
ci: Enable Meson builds again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_install:
   - pyenv global system 3.6
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja python3; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install meson; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip3 install meson; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install 'meson>=0.44.1'; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip3 install 'meson>=0.44.1'; fi
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir .ntmp && curl -L https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip -o .ntmp/ninja-linux.zip; fi
@@ -27,9 +27,9 @@ before_script:
   - export PATH=$PATH:$PWD/.ntmp
 
 script:
-  #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then meson build && ninja -j8 -C build; fi
-  #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ninja -j8 -C build test -v; fi
-  #- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) meson build && ninja -j8 -C build test; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then meson build && ninja -j8 -C build; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ninja -j8 -C build test -v; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) meson build && ninja -j8 -C build test; fi
   - dub build
   - dub test --build=unittest-cov
 after_success:


### PR DESCRIPTION
This reverts commit 25e3a4fa652ca0a023570ccf498496e31e264292 and adds a
dependency on a bugfixed version of Meson.

With the Meson bugfix release 0.44.1, all D and subproject related issues have been resolved and are unittested now.