### PR TITLE
make dub.json more standard-compliant

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -13,6 +13,6 @@
     {
         "debug": { "buildOptions": ["debugMode"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline", "noBoundsCheck"] },
-        "profile": { "buildOptions": ["releaseMode", "optimize", "noBoundsCheck"] },
-    },
+        "profile": { "buildOptions": ["releaseMode", "optimize", "noBoundsCheck"] }
+    }
 }


### PR DESCRIPTION
Dub might accept it now, but if it ever adopts a stricter json parser, this project's dub.json might fail to parse.

This PR fixes that.