### PR TITLE
remove redundant BOM definitions

### DIFF
--- a/source/dyaml/emitter.d
+++ b/source/dyaml/emitter.d
@@ -15,6 +15,7 @@ import std.array;
 import std.ascii;
 import std.container;
 import std.conv;
+import std.encoding;
 import std.exception;
 import std.format;
 import std.range;
@@ -1166,14 +1167,14 @@ struct Emitter
                 case Encoding.UTF_8:
                     break;
                 case Encoding.UTF_16:
-                    bom = std.system.endian == Endian.littleEndian 
-                          ? ByteOrderMarks[BOM.UTF16LE]
-                          : ByteOrderMarks[BOM.UTF16BE];
+                    bom = std.system.endian == Endian.littleEndian
+                          ? bomTable[BOM.utf16le].sequence
+                          : bomTable[BOM.utf16be].sequence;
                     break;
                 case Encoding.UTF_32:
-                    bom = std.system.endian == Endian.littleEndian 
-                          ? ByteOrderMarks[BOM.UTF32LE]  
-                          : ByteOrderMarks[BOM.UTF32BE];
+                    bom = std.system.endian == Endian.littleEndian
+                          ? bomTable[BOM.utf32le].sequence
+                          : bomTable[BOM.utf32be].sequence;
                     break;
             }
 

--- a/source/dyaml/reader.d
+++ b/source/dyaml/reader.d
@@ -990,9 +990,9 @@ void testEndian(R)()
 
 void testPeekPrefixForward(R)()
 {
-    import dyaml.stream;
+    import std.encoding;
     writeln(typeid(R).toString() ~ ": peek/prefix/forward unittest");
-    ubyte[] data = ByteOrderMarks[BOM.UTF8] ~ cast(ubyte[])"data";
+    ubyte[] data = bomTable[BOM.utf8].sequence ~ cast(ubyte[])"data";
     auto reader = new R(data);
     assert(reader.peek() == 'd');
     assert(reader.peek(1) == 'a');
@@ -1008,12 +1008,12 @@ void testPeekPrefixForward(R)()
 
 void testUTF(R)()
 {
-    import dyaml.stream;
+    import std.encoding;
     writeln(typeid(R).toString() ~ ": UTF formats unittest");
     dchar[] data = cast(dchar[])"data";
     void utf_test(T)(T[] data, BOM bom)
     {
-        ubyte[] bytes = ByteOrderMarks[bom] ~
+        ubyte[] bytes = bomTable[bom].sequence ~
                         (cast(ubyte[])data)[0 .. data.length * T.sizeof];
         auto reader = new R(bytes);
         assert(reader.peek() == 'd');
@@ -1021,9 +1021,9 @@ void testUTF(R)()
         assert(reader.peek(2) == 't');
         assert(reader.peek(3) == 'a');
     }
-    utf_test!char(to!(char[])(data), BOM.UTF8);
-    utf_test!wchar(to!(wchar[])(data), endian == Endian.bigEndian ? BOM.UTF16BE : BOM.UTF16LE);
-    utf_test(data, endian == Endian.bigEndian ? BOM.UTF32BE : BOM.UTF32LE);
+    utf_test!char(to!(char[])(data), BOM.utf8);
+    utf_test!wchar(to!(wchar[])(data), endian == Endian.bigEndian ? BOM.utf16be : BOM.utf16le);
+    utf_test(data, endian == Endian.bigEndian ? BOM.utf32be : BOM.utf32le);
 }
 
 void test1Byte(R)()

--- a/source/dyaml/stream.d
+++ b/source/dyaml/stream.d
@@ -1,33 +1,5 @@
 module dyaml.stream;
 
-enum BOM
-{
-    UTF8,           /// UTF-8
-    UTF16LE,        /// UTF-16 Little Endian
-    UTF16BE,        /// UTF-16 Big Endian
-    UTF32LE,        /// UTF-32 Little Endian
-    UTF32BE,        /// UTF-32 Big Endian
-}
-
-import std.system;
-
-private enum int NBOMS = 5;
-immutable Endian[NBOMS] BOMEndian =
-[
-    std.system.endian,
-    Endian.littleEndian, Endian.bigEndian,
-    Endian.littleEndian, Endian.bigEndian
-];
-
-immutable ubyte[][NBOMS] ByteOrderMarks =
-[
-    [0xEF, 0xBB, 0xBF],
-    [0xFF, 0xFE],
-    [0xFE, 0xFF],
-    [0xFF, 0xFE, 0x00, 0x00],
-    [0x00, 0x00, 0xFE, 0xFF]
-];
-
 interface YStream
 {
     void writeExact(const void* buffer, size_t size);


### PR DESCRIPTION
These also exist in std.encoding. We don't need to duplicate them here.