### PR TITLE
remove misleading Error = _____Exception aliases

### DIFF
--- a/source/dyaml/constructor.d
+++ b/source/dyaml/constructor.d
@@ -46,8 +46,6 @@ package class ConstructorException : YAMLException
     }
 }
 
-private alias ConstructorException Error;
-
 /** Constructs YAML values.
  *
  * Each YAML scalar, sequence or mapping has a tag specifying its data type.
@@ -310,7 +308,7 @@ final class Constructor
                         is(T == Node.Pair[]) ? "mapping"  :
                                                "ERROR";
             enforce((tag in *delegates!T) !is null,
-                    new Error("No constructor function from " ~ type ~
+                    new ConstructorException("No constructor function from " ~ type ~
                               " for tag " ~ tag, start, end));
 
             Node node = Node(value);
@@ -330,7 +328,7 @@ final class Constructor
             }
             catch(Exception e)
             {
-                throw new Error("Error constructing " ~ typeid(T).toString()
+                throw new ConstructorException("Error constructing " ~ typeid(T).toString()
                                 ~ ":\n" ~ e.msg, start, end);
             }
         }

--- a/source/dyaml/emitter.d
+++ b/source/dyaml/emitter.d
@@ -50,8 +50,6 @@ class EmitterException : YAMLException
     mixin ExceptionCtors;
 }
 
-private alias EmitterException Error;
-
 //Stores results of analysis of a scalar, determining e.g. what scalar style to use.
 struct ScalarAnalysis
 {
@@ -241,7 +239,7 @@ struct Emitter
             }
             catch(Exception e)
             {
-                throw new Error("Unable to write to stream: " ~ e.msg);
+                throw new EmitterException("Unable to write to stream: " ~ e.msg);
             }
         }
 
@@ -304,7 +302,7 @@ struct Emitter
         bool eventTypeIs(in EventID id) const pure @safe
         {
             enforce(!event_.isNull,
-                    new Error("Expected an event, but no event is available."));
+                    new EmitterException("Expected an event, but no event is available."));
             return event_.id == id;
         }
 
@@ -318,7 +316,7 @@ struct Emitter
         void expectStreamStart() @trusted
         {
             enforce(eventTypeIs(EventID.StreamStart),
-                    new Error("Expected YStreamStart, but got " ~ event_.idString));
+                    new EmitterException("Expected YStreamStart, but got " ~ event_.idString));
 
             encoding_ = event_.encoding;
             writeStreamStart();
@@ -328,7 +326,7 @@ struct Emitter
         ///Expect nothing, throwing if we still have something.
         void expectNothing() const @safe
         {
-            throw new Error("Expected nothing, but got " ~ event_.idString);
+            throw new EmitterException("Expected nothing, but got " ~ event_.idString);
         }
 
         //Document handlers.
@@ -337,7 +335,7 @@ struct Emitter
         void expectDocumentStart(Flag!"first" first)() @trusted
         {
             enforce(eventTypeIs(EventID.DocumentStart) || eventTypeIs(EventID.StreamEnd),
-                    new Error("Expected DocumentStart or YStreamEnd, but got " 
+                    new EmitterException("Expected DocumentStart or YStreamEnd, but got "
                               ~ event_.idString));
 
             if(event_.id == EventID.DocumentStart)
@@ -404,7 +402,7 @@ struct Emitter
         void expectDocumentEnd() @trusted
         {
             enforce(eventTypeIs(EventID.DocumentEnd),
-                    new Error("Expected DocumentEnd, but got " ~ event_.idString));
+                    new EmitterException("Expected DocumentEnd, but got " ~ event_.idString));
 
             writeIndent();
             if(event_.explicitDocument)
@@ -477,14 +475,14 @@ struct Emitter
                      }
                      break;
                 default:
-                     throw new Error("Expected Alias, Scalar, SequenceStart or " ~
+                     throw new EmitterException("Expected Alias, Scalar, SequenceStart or " ~
                                      "MappingStart, but got: " ~ event_.idString);
             }
         }
         ///Handle an alias.
         void expectAlias() @trusted
         {
-            enforce(event_.anchor !is null, new Error("Anchor is not specified for alias"));
+            enforce(event_.anchor !is null, new EmitterException("Anchor is not specified for alias"));
             processAnchor("*");
             state_ = popState();
         }
@@ -811,7 +809,7 @@ struct Emitter
                 return;
             }
 
-            enforce(tag !is null, new Error("Tag is not specified"));
+            enforce(tag !is null, new EmitterException("Tag is not specified"));
             if(preparedTag_ is null){preparedTag_ = prepareTag(tag);}
             if(preparedTag_ !is null && preparedTag_ != "")
             {
@@ -867,7 +865,7 @@ struct Emitter
         static string prepareVersion(const string YAMLVersion) @safe
         {
             enforce(YAMLVersion.split(".")[0] == "1",
-                    new Error("Unsupported YAML version: " ~ YAMLVersion));
+                    new EmitterException("Unsupported YAML version: " ~ YAMLVersion));
             return YAMLVersion;
         }
 
@@ -887,12 +885,12 @@ struct Emitter
         static string prepareTagHandle(const string handle) @safe
         {
             enforce(handle !is null && handle != "",
-                    new Error("Tag handle must not be empty"));
+                    new EmitterException("Tag handle must not be empty"));
 
             if(handle.length > 1) foreach(const dchar c; handle[1 .. $ - 1])
             {
                 enforce(isAlphaNum(c) || "-_"d.canFind(c),
-                        new Error("Invalid character: " ~ to!string(c)  ~
+                        new EmitterException("Invalid character: " ~ to!string(c)  ~
                                   " in tag handle " ~ handle));
             }
             return handle;
@@ -902,7 +900,7 @@ struct Emitter
         static string prepareTagPrefix(const string prefix) @safe
         {
             enforce(prefix !is null && prefix != "",
-                    new Error("Tag prefix must not be empty"));
+                    new EmitterException("Tag prefix must not be empty"));
 
             auto appender = appender!string();
             const offset = prefix[0] == '!' ? 1 : 0;
@@ -932,7 +930,7 @@ struct Emitter
         ///Prepare tag for output.
         string prepareTag(in string tag) @safe
         {
-            enforce(tag !is null, new Error("Tag must not be empty"));
+            enforce(tag !is null, new EmitterException("Tag must not be empty"));
 
             string tagString = tag;
             if(tagString == "!"){return tagString;}
@@ -980,12 +978,12 @@ struct Emitter
         static string prepareAnchor(const string anchor) @safe
         {
             enforce(anchor != "",
-                    new Error("Anchor must not be empty"));
+                    new EmitterException("Anchor must not be empty"));
             const str = anchor;
             foreach(const dchar c; str)
             {
                 enforce(isAlphaNum(c) || "-_"d.canFind(c),
-                        new Error("Invalid character: " ~ to!string(c) ~ " in anchor: " ~ str));
+                        new EmitterException("Invalid character: " ~ to!string(c) ~ " in anchor: " ~ str));
             }
             return str;
         }
@@ -1178,7 +1176,7 @@ struct Emitter
                     break;
             }
 
-            enforce(stream_.write(bom) == bom.length, new Error("Unable to write to stream"));
+            enforce(stream_.write(bom) == bom.length, new EmitterException("Unable to write to stream"));
         }
 
         ///End the YAML stream.

--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -41,8 +41,6 @@ class NodeException : YAMLException
         }
 }
 
-private alias NodeException Error;
-
 // Node kinds.
 package enum NodeID : ubyte
 {
@@ -611,7 +609,7 @@ struct Node
                 {
                     return (cast(YAMLContainer!T)object).value_;
                 }
-                throw new Error("Node stores unexpected type: " ~ object.type.toString() ~
+                throw new NodeException("Node stores unexpected type: " ~ object.type.toString() ~
                                 ". Expected: " ~ typeid(T).toString, startMark_);
             }
 
@@ -624,7 +622,7 @@ struct Node
                 static if(!stringConversion)
                 {
                     if(isString){return to!T(value_.get!string);}
-                    throw new Error("Node stores unexpected type: " ~ type.toString() ~
+                    throw new NodeException("Node stores unexpected type: " ~ type.toString() ~
                                     ". Expected: " ~ typeid(T).toString, startMark_);
                 }
                 else
@@ -636,7 +634,7 @@ struct Node
                     }
                     catch(VariantException e)
                     {
-                        throw new Error("Unable to convert node value to string", startMark_);
+                        throw new NodeException("Unable to convert node value to string", startMark_);
                     }
                 }
             }
@@ -659,14 +657,14 @@ struct Node
                     {
                         const temp = value_.get!(const long);
                         enforce(temp >= T.min && temp <= T.max,
-                            new Error("Integer value of type " ~ typeid(T).toString() ~
+                            new NodeException("Integer value of type " ~ typeid(T).toString() ~
                                       " out of range. Value: " ~ to!string(temp), startMark_));
                         return to!T(temp);
                     }
-                    throw new Error("Node stores unexpected type: " ~ type.toString() ~
+                    throw new NodeException("Node stores unexpected type: " ~ type.toString() ~
                         ". Expected: " ~ typeid(T).toString(), startMark_);
                 }
-                else throw new Error("Node stores unexpected type: " ~ type.toString() ~
+                else throw new NodeException("Node stores unexpected type: " ~ type.toString() ~
                                 ". Expected: " ~ typeid(T).toString(), startMark_);
             }
             assert(false, "This code should never be reached");
@@ -691,7 +689,7 @@ struct Node
                 {
                     return (cast(const YAMLContainer!(Unqual!T))object).value_;
                 }
-                throw new Error("Node has unexpected type: " ~ object.type.toString() ~
+                throw new NodeException("Node has unexpected type: " ~ object.type.toString() ~
                                 ". Expected: " ~ typeid(T).toString, startMark_);
             }
 
@@ -704,7 +702,7 @@ struct Node
                 static if(!stringConversion)
                 {
                     if(isString){return to!T(value_.get!(const string));}
-                    throw new Error("Node stores unexpected type: " ~ type.toString() ~
+                    throw new NodeException("Node stores unexpected type: " ~ type.toString() ~
                                     ". Expected: " ~ typeid(T).toString(), startMark_);
                 }
                 else
@@ -717,7 +715,7 @@ struct Node
                     }
                     catch(VariantException e)
                     {
-                        throw new Error("Unable to convert node value to string", startMark_);
+                        throw new NodeException("Unable to convert node value to string", startMark_);
                     }
                 }
             }
@@ -738,11 +736,11 @@ struct Node
                 {
                     const temp = value_.get!(const long);
                     enforce(temp >= T.min && temp <= T.max,
-                            new Error("Integer value of type " ~ typeid(T).toString() ~
+                            new NodeException("Integer value of type " ~ typeid(T).toString() ~
                                       " out of range. Value: " ~ to!string(temp), startMark_));
                     return to!T(temp);
                 }
-                throw new Error("Node stores unexpected type: " ~ type.toString() ~
+                throw new NodeException("Node stores unexpected type: " ~ type.toString() ~
                                 ". Expected: " ~ typeid(T).toString, startMark_);
             }
         }
@@ -759,7 +757,7 @@ struct Node
         {
             if(isSequence)    {return value_.get!(const Node[]).length;}
             else if(isMapping){return value_.get!(const Pair[]).length;}
-            throw new Error("Trying to get length of a " ~ nodeTypeString ~ " node",
+            throw new NodeException("Trying to get length of a " ~ nodeTypeString ~ " node",
                             startMark_);
         }
 
@@ -802,9 +800,9 @@ struct Node
                 }
 
                 string msg = "Mapping index not found" ~ (isSomeString!T ? ": " ~ to!string(index) : "");
-                throw new Error(msg, startMark_);
+                throw new NodeException(msg, startMark_);
             }
-            throw new Error("Trying to index a " ~ nodeTypeString ~ " node", startMark_);
+            throw new NodeException("Trying to index a " ~ nodeTypeString ~ " node", startMark_);
         }
         ///
         @safe unittest
@@ -1005,7 +1003,7 @@ struct Node
                 return;
             }
 
-            throw new Error("Trying to index a " ~ nodeTypeString ~ " node", startMark_);
+            throw new NodeException("Trying to index a " ~ nodeTypeString ~ " node", startMark_);
         }
         @safe unittest
         {
@@ -1051,7 +1049,7 @@ struct Node
         auto sequence(T = Node)()
         {
             enforce(isSequence,
-                    new Error("Trying to 'sequence'-iterate over a " ~ nodeTypeString ~ " node",
+                    new NodeException("Trying to 'sequence'-iterate over a " ~ nodeTypeString ~ " node",
                         startMark_));
             struct Range
             {
@@ -1140,7 +1138,7 @@ struct Node
         auto mapping() @safe
         {
             enforce(isMapping,
-                    new Error("Trying to 'mapping'-iterate over a "
+                    new NodeException("Trying to 'mapping'-iterate over a "
                         ~ nodeTypeString ~ " node", startMark_));
             struct Range
             {
@@ -1225,7 +1223,7 @@ struct Node
         auto mappingKeys(K = Node)()
         {
             enforce(isMapping,
-                    new Error("Trying to 'mappingKeys'-iterate over a " 
+                    new NodeException("Trying to 'mappingKeys'-iterate over a "
                         ~ nodeTypeString ~ " node", startMark_));
             static if (is(Unqual!K == Node))
                 return mapping.map!(pair => pair.key);
@@ -1255,7 +1253,7 @@ struct Node
         auto mappingValues(V = Node)()
         {
             enforce(isMapping,
-                    new Error("Trying to 'mappingValues'-iterate over a " 
+                    new NodeException("Trying to 'mappingValues'-iterate over a "
                         ~ nodeTypeString ~ " node", startMark_));
             static if (is(Unqual!V == Node))
                 return mapping.map!(pair => pair.value);
@@ -1285,7 +1283,7 @@ struct Node
         int opApply(T)(int delegate(ref T) dg) @trusted
         {
             enforce(isSequence,
-                    new Error("Trying to sequence-foreach over a " ~ nodeTypeString ~ " node",
+                    new NodeException("Trying to sequence-foreach over a " ~ nodeTypeString ~ " node",
                               startMark_));
 
             int result = 0;
@@ -1341,7 +1339,7 @@ struct Node
         int opApply(K, V)(int delegate(ref K, ref V) dg) @trusted
         {
             enforce(isMapping,
-                    new Error("Trying to mapping-foreach over a " ~ nodeTypeString ~ " node",
+                    new NodeException("Trying to mapping-foreach over a " ~ nodeTypeString ~ " node",
                               startMark_));
 
             int result = 0;
@@ -1440,7 +1438,7 @@ struct Node
         void add(T)(T value) @trusted
         {
             enforce(isSequence(),
-                    new Error("Trying to add an element to a " ~ nodeTypeString ~ " node", startMark_));
+                    new NodeException("Trying to add an element to a " ~ nodeTypeString ~ " node", startMark_));
 
             auto nodes = get!(Node[])();
             static if(is(Unqual!T == Node)){nodes ~= value;}
@@ -1476,7 +1474,7 @@ struct Node
         void add(K, V)(K key, V value) @trusted
         {
             enforce(isMapping(),
-                    new Error("Trying to add a key-value pair to a " ~
+                    new NodeException("Trying to add a key-value pair to a " ~
                               nodeTypeString ~ " node",
                               startMark_));
 
@@ -1511,7 +1509,7 @@ struct Node
         Node* opBinaryRight(string op, K)(K key)
             if (op == "in")
         {
-            enforce(isMapping, new Error("Trying to use 'in' on a " ~
+            enforce(isMapping, new NodeException("Trying to use 'in' on a " ~
                                          nodeTypeString ~ " node", startMark_));
 
             auto idx = findPair(key);
@@ -1957,7 +1955,7 @@ struct Node
                 return findPair!(T, key)(rhs) >= 0;
             }
 
-            throw new Error("Trying to use " ~ func ~ "() on a " ~ nodeTypeString ~ " node",
+            throw new NodeException("Trying to use " ~ func ~ "() on a " ~ nodeTypeString ~ " node",
                             startMark_);
         }
 
@@ -1965,7 +1963,7 @@ struct Node
         void remove_(T, Flag!"key" key, string func)(T rhs)
         {
             enforce(isSequence || isMapping,
-                    new Error("Trying to " ~ func ~ "() from a " ~ nodeTypeString ~ " node",
+                    new NodeException("Trying to " ~ func ~ "() from a " ~ nodeTypeString ~ " node",
                               startMark_));
 
             static void removeElem(E, I)(ref Node node, I index)
@@ -2037,12 +2035,12 @@ struct Node
 
             static if(!isIntegral!T)
             {
-                throw new Error("Indexing a sequence with a non-integral type.", startMark_);
+                throw new NodeException("Indexing a sequence with a non-integral type.", startMark_);
             }
             else
             {
                 enforce(index >= 0 && index < value_.get!(const Node[]).length,
-                        new Error("Sequence index out of range: " ~ to!string(index),
+                        new NodeException("Sequence index out of range: " ~ to!string(index),
                                   startMark_));
             }
         }
@@ -2068,9 +2066,9 @@ struct Node
                 }
 
                 string msg = "Mapping index not found" ~ (isSomeString!T ? ": " ~ to!string(index) : "");
-                throw new Error(msg, startMark_);
+                throw new NodeException(msg, startMark_);
             }
-            throw new Error("Trying to index a " ~ nodeTypeString ~ " node", startMark_);
+            throw new NodeException("Trying to index a " ~ nodeTypeString ~ " node", startMark_);
         }
 }
 

--- a/source/dyaml/parser.d
+++ b/source/dyaml/parser.d
@@ -100,8 +100,6 @@ class ParserException : MarkedYAMLException
     mixin MarkedExceptionCtors;
 }
 
-private alias ParserException Error;
-
 /// Generates events from tokens provided by a Scanner.
 ///
 /// While Parser receives tokens with non-const character slices, the events it 
@@ -292,7 +290,7 @@ final class Parser
 
                 auto tagDirectives = processDirectives();
                 enforce(scanner_.checkToken(TokenID.DocumentStart),
-                        new Error("Expected document start but found " ~
+                        new ParserException("Expected document start but found " ~
                                   scanner_.peekToken().idString,
                                   scanner_.peekToken().startMark));
 
@@ -351,10 +349,10 @@ final class Parser
                 if(token.directive == DirectiveType.YAML)
                 {
                     enforce(YAMLVersion_ is null,
-                            new Error("Duplicate YAML directive", token.startMark));
+                            new ParserException("Duplicate YAML directive", token.startMark));
                     const minor = value.split(".")[0];
                     enforce(minor == "1",
-                            new Error("Incompatible document (version 1.x is required)",
+                            new ParserException("Incompatible document (version 1.x is required)",
                                       token.startMark));
                     YAMLVersion_ = value;
                 }
@@ -366,7 +364,7 @@ final class Parser
                     {
                         // handle
                         const h = pair.handle;
-                        enforce(h != handle, new Error("Duplicate tag handle: " ~ handle,
+                        enforce(h != handle, new ParserException("Duplicate tag handle: " ~ handle,
                                                        token.startMark));
                     }
                     tagDirectives_ ~=
@@ -528,7 +526,7 @@ final class Parser
             }
 
             const token = scanner_.peekToken();
-            throw new Error("While parsing a " ~ (block ? "block" : "flow") ~ " node",
+            throw new ParserException("While parsing a " ~ (block ? "block" : "flow") ~ " node",
                             startMark, "expected node content, but found: "
                             ~ token.idString, token.startMark);
         }
@@ -641,7 +639,7 @@ final class Parser
                 }
                 //handle must be in tagDirectives_
                 enforce(replacement !is null,
-                        new Error("While parsing a node", startMark,
+                        new ParserException("While parsing a node", startMark,
                                   "found undefined tag handle: " ~ handle, tagMark));
                 return replacement ~ suffix;
             }
@@ -676,7 +674,7 @@ final class Parser
             if(!scanner_.checkToken(TokenID.BlockEnd))
             {
                 const token = scanner_.peekToken();
-                throw new Error("While parsing a block collection", marks_.back,
+                throw new ParserException("While parsing a block collection", marks_.back,
                                 "expected block end, but found " ~ token.idString,
                                 token.startMark);
             }
@@ -741,7 +739,7 @@ final class Parser
             if(!scanner_.checkToken(TokenID.BlockEnd))
             {
                 const token = scanner_.peekToken();
-                throw new Error("While parsing a block mapping", marks_.back,
+                throw new ParserException("While parsing a block mapping", marks_.back,
                                 "expected block end, but found: " ~ token.idString,
                                 token.startMark);
             }
@@ -802,7 +800,7 @@ final class Parser
                     else
                     {
                         const token = scanner_.peekToken();
-                        throw new Error("While parsing a flow sequence", marks_.back,
+                        throw new ParserException("While parsing a flow sequence", marks_.back,
                                         "expected ',' or ']', but got: " ~
                                         token.idString, token.startMark);
                     }
@@ -910,7 +908,7 @@ final class Parser
                     else
                     {
                         const token = scanner_.peekToken();
-                        throw new Error("While parsing a flow mapping", marks_.back,
+                        throw new ParserException("While parsing a flow mapping", marks_.back,
                                         "expected ',' or '}', but got: " ~
                                         token.idString, token.startMark);
                     }


### PR DESCRIPTION
Throwing Errors is typically only done for errors that aren't meant to be recovered from. The Errors thrown here aren't using the same class found in object (as far as I can tell) and are really just aliases for other Exceptions, but it can be rather misleading nonetheless.