### PR TITLE
Convert tests to doc'd examples and some minor doc param fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ Thumbs.db
 perf.data
 perf.data.old
 callgrind.out.*
+
+# Test outputs #
+example.yaml

--- a/source/dyaml/dumper.d
+++ b/source/dyaml/dumper.d
@@ -31,52 +31,10 @@ import dyaml.tagdirective;
 /**
  * Dumps YAML documents to files or streams.
  *
- * User specified Representer and/or Resolver can be used to support new 
+ * User specified Representer and/or Resolver can be used to support new
  * tags / data types.
  *
  * Setters are provided to affect output details (style, encoding, etc.).
- * 
- * Examples: 
- *
- * Write to a file:
- * --------------------
- * auto node = Node([1, 2, 3, 4, 5]);
- * Dumper("file.yaml").dump(node);
- * --------------------
- *
- * Write multiple YAML documents to a file:
- * --------------------
- * auto node1 = Node([1, 2, 3, 4, 5]);
- * auto node2 = Node("This document contains only one string");
- * Dumper("file.yaml").dump(node1, node2);
- *
- * //Or with an array:
- * //Dumper("file.yaml").dump([node1, node2]);
- *
- *
- * --------------------
- *
- * Write to memory:
- * --------------------
- * import std.stream;
- * auto stream = new YMemoryStream();
- * auto node = Node([1, 2, 3, 4, 5]);
- * Dumper(stream).dump(node);
- * --------------------
- *
- * Use a custom representer/resolver to support custom data types and/or implicit tags:
- * --------------------
- * auto node = Node([1, 2, 3, 4, 5]);
- * auto representer = new Representer();
- * auto resolver = new Resolver();
- *
- * //Add representer functions / resolver expressions here...
- *
- * auto dumper = Dumper("file.yaml");
- * dumper.representer = representer;
- * dumper.resolver = resolver;
- * dumper.dump(node);
- * --------------------
  */
 struct Dumper
 {
@@ -271,21 +229,10 @@ struct Dumper
          *
          * Each prefix MUST not be empty.
          *
-         * The "!!" handle is used for default YAML _tags with prefix 
+         * The "!!" handle is used for default YAML _tags with prefix
          * "tag:yaml.org,2002:". This can be overridden.
          *
          * Params:  tags = Tag directives (keys are handles, values are prefixes).
-         *
-         * Example:
-         * --------------------
-         * Dumper dumper = Dumper("file.yaml");
-         * string[string] directives;
-         * directives["!short!"] = "tag:long.org,2011:";
-         * //This will emit tags starting with "tag:long.org,2011"
-         * //with a "!short!" prefix instead.
-         * dumper.tagDirectives(directives);
-         * dumper.dump(Node("foo"));
-         * --------------------
          */
         @property void tagDirectives(string[string] tags) pure @safe
         {
@@ -299,6 +246,17 @@ struct Dumper
                 t ~= TagDirective(handle, prefix);
             }
             tags_ = t;
+        }
+        ///
+        @safe unittest
+        {
+            Dumper dumper = Dumper("example.yaml");
+            string[string] directives;
+            directives["!short!"] = "tag:long.org,2011:";
+            //This will emit tags starting with "tag:long.org,2011"
+            //with a "!short!" prefix instead.
+            dumper.tagDirectives(directives);
+            dumper.dump(Node("foo"));
         }
 
         /**
@@ -356,4 +314,39 @@ struct Dumper
                                         ~ name_ ~ " : " ~ e.msg);
             }
         }
+}
+///Write to a file
+@safe unittest
+{
+    auto node = Node([1, 2, 3, 4, 5]);
+    Dumper("example.yaml").dump(node);
+}
+///Write multiple YAML documents to a file
+@safe unittest
+{
+    auto node1 = Node([1, 2, 3, 4, 5]);
+    auto node2 = Node("This document contains only one string");
+    Dumper("example.yaml").dump(node1, node2);
+    //Or with an array:
+    Dumper("example.yaml").dump([node1, node2]);
+}
+///Write to memory
+@safe unittest
+{
+    import dyaml.stream;
+    auto stream = new YMemoryStream();
+    auto node = Node([1, 2, 3, 4, 5]);
+    Dumper(stream).dump(node);
+}
+///Use a custom representer/resolver to support custom data types and/or implicit tags
+@safe unittest
+{
+    auto node = Node([1, 2, 3, 4, 5]);
+    auto representer = new Representer();
+    auto resolver = new Resolver();
+    //Add representer functions / resolver expressions here...
+    auto dumper = Dumper("example.yaml");
+    dumper.representer = representer;
+    dumper.resolver = resolver;
+    dumper.dump(node);
 }

--- a/source/dyaml/event.d
+++ b/source/dyaml/event.d
@@ -123,6 +123,7 @@ Event event(EventID id)(const Mark start, const Mark end, const string anchor = 
  *          anchor   = Anchor of the sequence, if any.
  *          tag      = Tag of the sequence, if specified.
  *          implicit = Should the tag be implicitly resolved?
+ *          style = Style to use when outputting document.
  */
 Event collectionStartEvent(EventID id)
     (const Mark start, const Mark end, const string anchor, const string tag,

--- a/source/dyaml/flags.d
+++ b/source/dyaml/flags.d
@@ -17,20 +17,6 @@ package:
  * Struct holding multiple named boolean values in a single byte.
  *
  * Can hold at most 8 values.
- *
- * Example:
- * --------------------
- * Flags!("empty", "multiline") flags;
- * assert(flags.empty == false && flags.multiline == false);
- * flags.multiline = true;
- * assert(flags.empty == false && flags.multiline == true);
- * flags.empty = true;
- * assert(flags.empty == true && flags.multiline == true);
- * flags.multiline = false;
- * assert(flags.empty == true && flags.multiline == false);
- * flags.empty = false;
- * assert(flags.empty == false && flags.multiline == false);
- * --------------------
  */
 struct Flags(names ...) if(names.length <= 8)
 {
@@ -72,6 +58,7 @@ struct Flags(names ...) if(names.length <= 8)
         ///Flag accessors.
         mixin(flags(names));
 }
+///
 @safe unittest
 {
     import std.stdio;

--- a/source/dyaml/hacks.d
+++ b/source/dyaml/hacks.d
@@ -23,21 +23,21 @@ import dyaml.style;
  * However, determining style may be useful in some cases, e.g. YAML utilities.
  *
  * May only be called on scalar nodes (nodes where node.isScalar() == true).
- *
- * Example:
- * --------------------
- * // Node node // loaded from a file
- * if(node.isScalar)
- * {
- *     import std.stdio;
- *     writeln(node.scalarStyleHack());
- * }
- * --------------------
  */
 ScalarStyle scalarStyleHack(ref const(Node) node) @safe nothrow
 {
     assert(node.isScalar, "Trying to get scalar style of a non-scalar node");
     return node.scalarStyle;
+}
+///
+@safe unittest
+{
+    import dyaml;
+    Node node = Loader.fromString(`"42"`.dup).load(); // loaded from a file
+    if(node.isScalar)
+    {
+        assert(node.scalarStyleHack() == ScalarStyle.DoubleQuoted);
+    }
 }
 @safe unittest
 {

--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -311,13 +311,6 @@ struct Node
          *                  must be in full form, e.g. "tag:yaml.org,2002:set",
          *                  not a shortcut, like "!!set".
          *
-         * Examples:
-         * --------------------
-         * // Will be emitted as a sequence (default for arrays)
-         * auto seq = Node([1, 2, 3, 4, 5]);
-         * // Will be emitted as a set (overriden tag)
-         * auto set = Node([1, 2, 3, 4, 5], "tag:yaml.org,2002:set");
-         * --------------------
          */
         this(T)(T[] array, const string tag = null) @trusted
             if (!isSomeString!(T[]))
@@ -341,6 +334,14 @@ struct Node
                 value_ = Value(nodes);
             }
         }
+        ///
+        @safe unittest
+        {
+            // Will be emitted as a sequence (default for arrays)
+            auto seq = Node([1, 2, 3, 4, 5]);
+            // Will be emitted as a set (overriden tag)
+            auto set = Node([1, 2, 3, 4, 5], "tag:yaml.org,2002:set");
+        }
         @safe unittest
         {
             with(Node([1, 2, 3]))
@@ -350,10 +351,6 @@ struct Node
                 assert(opIndex(2).as!int == 3);
             }
 
-            // Will be emitted as a sequence (default for arrays)
-            auto seq = Node([1, 2, 3, 4, 5]);
-            // Will be emitted as a set (overriden tag)
-            auto set = Node([1, 2, 3, 4, 5], "tag:yaml.org,2002:set");
         }
 
         /** Construct a node from an associative _array.
@@ -373,15 +370,6 @@ struct Node
          *                  in full form, e.g. "tag:yaml.org,2002:omap", not a
          *                  shortcut, like "!!omap".
          *
-         * Examples:
-         * --------------------
-         * // Will be emitted as an unordered mapping (default for mappings)
-         * auto map   = Node([1 : "a", 2 : "b"]);
-         * // Will be emitted as an ordered map (overriden tag)
-         * auto omap  = Node([1 : "a", 2 : "b"], "tag:yaml.org,2002:omap");
-         * // Will be emitted as pairs (overriden tag)
-         * auto pairs = Node([1 : "a", 2 : "b"], "tag:yaml.org,2002:pairs");
-         * --------------------
          */
         this(K, V)(V[K] array, const string tag = null) @trusted
         {
@@ -390,6 +378,16 @@ struct Node
             Node.Pair[] pairs;
             foreach(key, ref value; array){pairs ~= Pair(key, value);}
             value_ = Value(pairs);
+        }
+        ///
+        @safe unittest
+        {
+            // Will be emitted as an unordered mapping (default for mappings)
+            auto map   = Node([1 : "a", 2 : "b"]);
+            // Will be emitted as an ordered map (overriden tag)
+            auto omap  = Node([1 : "a", 2 : "b"], "tag:yaml.org,2002:omap");
+            // Will be emitted as pairs (overriden tag)
+            auto pairs = Node([1 : "a", 2 : "b"], "tag:yaml.org,2002:pairs");
         }
         @safe unittest
         {
@@ -403,12 +401,6 @@ struct Node
                 assert(opIndex("2").as!int == 2);
             }
 
-            // Will be emitted as an unordered mapping (default for mappings)
-            auto map   = Node([1 : "a", 2 : "b"]);
-            // Will be emitted as an ordered map (overriden tag)
-            auto omap  = Node([1 : "a", 2 : "b"], "tag:yaml.org,2002:omap");
-            // Will be emitted as pairs (overriden tag)
-            auto pairs = Node([1 : "a", 2 : "b"], "tag:yaml.org,2002:pairs");
         }
 
         /** Construct a node from arrays of _keys and _values.
@@ -437,15 +429,6 @@ struct Node
          *                   in full form, e.g. "tag:yaml.org,2002:omap", not a
          *                   shortcut, like "!!omap".
          *
-         * Examples:
-         * --------------------
-         * // Will be emitted as an unordered mapping (default for mappings)
-         * auto map   = Node([1, 2], ["a", "b"]);
-         * // Will be emitted as an ordered map (overriden tag)
-         * auto omap  = Node([1, 2], ["a", "b"], "tag:yaml.org,2002:omap");
-         * // Will be emitted as pairs (overriden tag)
-         * auto pairs = Node([1, 2], ["a", "b"], "tag:yaml.org,2002:pairs");
-         * --------------------
          */
         this(K, V)(K[] keys, V[] values, const string tag = null) @trusted
             if(!(isSomeString!(K[]) || isSomeString!(V[])))
@@ -463,6 +446,16 @@ struct Node
             foreach(i; 0 .. keys.length){pairs ~= Pair(keys[i], values[i]);}
             value_ = Value(pairs);
         }
+        ///
+        @safe unittest
+        {
+            // Will be emitted as an unordered mapping (default for mappings)
+            auto map   = Node([1, 2], ["a", "b"]);
+            // Will be emitted as an ordered map (overridden tag)
+            auto omap  = Node([1, 2], ["a", "b"], "tag:yaml.org,2002:omap");
+            // Will be emitted as pairs (overriden tag)
+            auto pairs = Node([1, 2], ["a", "b"], "tag:yaml.org,2002:pairs");
+        }
         @safe unittest
         {
             with(Node(["1", "2"], [1, 2]))
@@ -472,12 +465,6 @@ struct Node
                 assert(opIndex("2").as!int == 2);
             }
 
-            // Will be emitted as an unordered mapping (default for mappings)
-            auto map   = Node([1, 2], ["a", "b"]);
-            // Will be emitted as an ordered map (overriden tag)
-            auto omap  = Node([1, 2], ["a", "b"], "tag:yaml.org,2002:omap");
-            // Will be emitted as pairs (overriden tag)
-            auto pairs = Node([1, 2], ["a", "b"], "tag:yaml.org,2002:pairs");
         }
 
         /// Is this node valid (initialized)?
@@ -580,17 +567,6 @@ struct Node
          * by old versions of the program, which expect the node to be a scalar.
          * )
          *
-         * Examples:
-         *
-         * Automatic type conversion:
-         * --------------------
-         * auto node = Node(42);
-         *
-         * assert(node.as!int == 42);
-         * assert(node.as!string == "42");
-         * assert(node.as!double == 42.0);
-         * --------------------
-         *
          * Returns: Value of the node as specified type.
          *
          * Throws:  NodeException if unable to convert to specified type, or if
@@ -668,6 +644,15 @@ struct Node
                                 ". Expected: " ~ typeid(T).toString(), startMark_);
             }
             assert(false, "This code should never be reached");
+        }
+        /// Automatic type conversion
+        @safe unittest
+        {
+            auto node = Node(42);
+
+            assert(node.get!int == 42);
+            assert(node.get!string == "42");
+            assert(node.get!double == 42.0);
         }
         @safe unittest
         {
@@ -968,7 +953,9 @@ struct Node
          *
          * To set element at a null index, use YAMLNull for index.
          *
-         * Params:  index = Index of the value to set.
+         * Params:
+         *          value = Value to assign.
+         *          index = Index of the value to set.
          *
          * Throws:  NodeException if the node is not a collection, index is out
          *          of range or if a non-integral index is used on a sequence node.

--- a/source/dyaml/nogcutil.d
+++ b/source/dyaml/nogcutil.d
@@ -363,17 +363,7 @@ auto decodeUTF8NoGC(Flag!"validated" validated)(const(char[]) str, ref size_t in
     else                 { return invalidUTF; }
 }
 
-/// @nogc version of std.utf.decode() for char[], but assumes str is valid UTF-8.
-///
-/// The caller $(B must) handle ASCII (< 0x80) characters manually; this is asserted to
-/// force code using this function to be efficient.
-///
-/// Params:
-///
-/// str   = Will decode the first code point from this string. Must be valid UTF-8,
-///         otherwise undefined behavior WILL occur.
-/// index = Index in str where the code point starts. Will be updated to point to the
-///         next code point.
+/// ditto
 alias decodeValidUTF8NoGC = decodeUTF8NoGC!(Yes.validated);
 
 /// @nogc version of std.utf.encode() for char[].
@@ -451,18 +441,7 @@ auto encodeCharNoGC(Flag!"validated" validated)(ref char[4] buf, dchar c)
     }
 }
 
-/// @nogc version of std.utf.encode() for char[], but assumes c is a valid UTF-32 char.
-///
-/// The caller $(B must) handle ASCII (< 0x80) characters manually; this is asserted to
-/// force code using this function to be efficient.
-///
-/// Params:
-///
-/// buf = Buffer to write the encoded result to.
-/// c   = Character to encode. Must be valid UTF-32, otherwise undefined behavior
-///       $(D will) occur.
-///
-/// Returns: Number of bytes the encoded character takes up in buf.
+/// ditto
 alias encodeValidCharNoGC = encodeCharNoGC!(Yes.validated);
 
 /// @nogc version of std.utf.isValidDchar

--- a/source/dyaml/resolver.d
+++ b/source/dyaml/resolver.d
@@ -92,28 +92,6 @@ final class Resolver
          *          regexp = Regular expression the scalar must match to have this _tag.
          *          first  = String of possible starting characters of the scalar.
          *
-         * Examples:
-         *
-         * Resolve scalars starting with 'A' to !_tag :
-         * --------------------
-         * import std.regex;
-         *
-         * import dyaml.all;
-         *
-         * void main()
-         * {
-         *     auto loader = Loader("file.txt");
-         *     auto resolver = new Resolver();
-         *     resolver.addImplicitResolver("!tag", std.regex.regex("A.*"), "A");
-         *     loader.resolver = resolver;
-         *     
-         *     //Note that we have no constructor from tag "!tag", so we can't
-         *     //actually load anything that resolves to this tag.
-         *     //See Constructor API documentation and tutorial for more information.
-         *
-         *     auto node = loader.load();
-         * }
-         * --------------------
          */
         void addImplicitResolver(string tag, Regex!char regexp, string first) 
             pure @safe 
@@ -126,6 +104,24 @@ final class Resolver
                 }
                 yamlImplicitResolvers_[c] ~= tuple(tag, regexp);
             }
+        }
+        /// Resolve scalars starting with 'A' to !_tag
+        unittest {
+            import std.regex;
+
+            import dyaml;
+
+
+            auto loader = Loader("example.yaml");
+            auto resolver = new Resolver();
+            resolver.addImplicitResolver("!tag", regex("A.*"), "A");
+            loader.resolver = resolver;
+
+            //Note that we have no constructor from tag "!tag", so we can't
+            //actually load anything that resolves to this tag.
+            //See Constructor API documentation and tutorial for more information.
+
+            //auto node = loader.load();
         }
 
     package:

--- a/source/dyaml/resolver.d
+++ b/source/dyaml/resolver.d
@@ -107,10 +107,12 @@ final class Resolver
         }
         /// Resolve scalars starting with 'A' to !_tag
         unittest {
+            import std.file : write;
             import std.regex;
 
             import dyaml;
 
+            write("example.yaml", "A");
 
             auto loader = Loader("example.yaml");
             auto resolver = new Resolver();

--- a/source/dyaml/token.d
+++ b/source/dyaml/token.d
@@ -103,6 +103,7 @@ static assert(Token.sizeof <= 32, "Token has unexpected size");
 ///          end       = End position of the token.
 ///          value     = Value of the token.
 ///          directive = Directive type (YAML or TAG in YAML 1.1).
+///          nameEnd = Position of the end of the name
 Token directiveToken(const Mark start, const Mark end, char[] value,
                      DirectiveType directive, const uint nameEnd) @safe pure nothrow @nogc
 {


### PR DESCRIPTION
Many of the examples actually didn't compile before due to small changes accumulating over time. This PR will help prevent that from happening by ensuring they get compiled along with the rest of the tests.

A few pieces of documentation were also missing some parameters.