### PR TITLE
convert verbose test variable to debug spec for easier access

### DIFF
--- a/source/dyaml/test/compare.d
+++ b/source/dyaml/test/compare.d
@@ -16,10 +16,9 @@ import dyaml.token;
 
 /// Test parser by comparing output from parsing two equivalent YAML files.
 ///
-/// Params:  verbose           = Print verbose output?
-///          dataFilename      = YAML file to parse.
+/// Params:  dataFilename      = YAML file to parse.
 ///          canonicalFilename = Another file to parse, in canonical YAML format.
-void testParser(bool verbose, string dataFilename, string canonicalFilename) @safe
+void testParser(string dataFilename, string canonicalFilename) @safe
 {
     auto dataEvents = Loader(dataFilename).parse();
     auto canonicalEvents = Loader(canonicalFilename).parse();
@@ -35,10 +34,9 @@ void testParser(bool verbose, string dataFilename, string canonicalFilename) @sa
 
 /// Test loader by comparing output from loading two equivalent YAML files.
 ///
-/// Params:  verbose           = Print verbose output?
-///          dataFilename      = YAML file to load.
+/// Params:  dataFilename      = YAML file to load.
 ///          canonicalFilename = Another file to load, in canonical YAML format.
-void testLoader(bool verbose, string dataFilename, string canonicalFilename) @safe
+void testLoader(string dataFilename, string canonicalFilename) @safe
 {
     auto data = Loader(dataFilename).loadAll();
     auto canonical = Loader(canonicalFilename).loadAll();
@@ -48,7 +46,7 @@ void testLoader(bool verbose, string dataFilename, string canonicalFilename) @sa
     {
         if(data[n] != canonical[n])
         {
-            if(verbose)
+            static if(verbose)
             {
                 writeln("Normal value:");
                 writeln(data[n].debugString);

--- a/source/dyaml/test/constructor.d
+++ b/source/dyaml/test/constructor.d
@@ -393,12 +393,11 @@ Node representStruct(ref Node node, Representer representer) @safe
 /**
  * Constructor unittest.
  *
- * Params:  verbose      = Print verbose output?
- *          dataFilename = File name to read from.
+ * Params:  dataFilename = File name to read from.
  *          codeDummy    = Dummy .code filename, used to determine that
  *                         .data file with the same name should be used in this test.
  */
-void testConstructor(bool verbose, string dataFilename, string codeDummy) @safe
+void testConstructor(string dataFilename, string codeDummy) @safe
 {
     string base = dataFilename.baseName.stripExtension;
     enforce((base in expected) !is null,
@@ -420,7 +419,7 @@ void testConstructor(bool verbose, string dataFilename, string codeDummy) @safe
     {
         if(!node.equals!(No.useTag)(exp[i]))
         {
-            if(verbose)
+            static if(verbose)
             {
                 writeln("Expected value:");
                 writeln(exp[i].debugString);

--- a/source/dyaml/test/emitter.d
+++ b/source/dyaml/test/emitter.d
@@ -75,11 +75,10 @@ bool compareEvents(Event[] events1, Event[] events2) @system
 /// the emitted result and comparing events from parsing the emitted result with
 /// originally parsed events.
 ///
-/// Params:  verbose           = Print verbose output?
-///          dataFilename      = YAML file to parse.
+/// Params:  dataFilename      = YAML file to parse.
 ///          canonicalFilename = Canonical YAML file used as dummy to determine
 ///                              which data files to load.
-void testEmitterOnData(bool verbose, string dataFilename, string canonicalFilename) @system
+void testEmitterOnData(string dataFilename, string canonicalFilename) @system
 {
     //Must exist due to Anchor, Tags reference counts.
     auto loader = Loader(dataFilename);
@@ -87,7 +86,7 @@ void testEmitterOnData(bool verbose, string dataFilename, string canonicalFilena
     auto emitStream = new YMemoryStream;
     Dumper(emitStream).emit(events);
 
-    if(verbose)
+    static if(verbose)
     {
         writeln(dataFilename);
         writeln("ORIGINAL:\n", readText(dataFilename));
@@ -106,9 +105,8 @@ void testEmitterOnData(bool verbose, string dataFilename, string canonicalFilena
 /// them both in canonical and normal format, parsing the emitted results and
 /// comparing events from parsing the emitted result with originally parsed events.
 ///
-/// Params:  verbose           = Print verbose output?
-///          canonicalFilename = Canonical YAML file to parse.
-void testEmitterOnCanonical(bool verbose, string canonicalFilename) @system
+/// Params:  canonicalFilename = Canonical YAML file to parse.
+void testEmitterOnCanonical(string canonicalFilename) @system
 {
     //Must exist due to Anchor, Tags reference counts.
     auto loader = Loader(canonicalFilename);
@@ -119,7 +117,7 @@ void testEmitterOnCanonical(bool verbose, string canonicalFilename) @system
         auto dumper = Dumper(emitStream);
         dumper.canonical = canonical;
         dumper.emit(events);
-        if(verbose)
+        static if(verbose)
         {
             writeln("OUTPUT (canonical=", canonical, "):\n",
                     cast(string)emitStream.data);
@@ -137,11 +135,10 @@ void testEmitterOnCanonical(bool verbose, string canonicalFilename) @system
 /// possible scalar and collection styles, parsing the emitted results and
 /// comparing events from parsing the emitted result with originally parsed events.
 ///
-/// Params:  verbose           = Print verbose output?
-///          dataFilename      = YAML file to parse.
+/// Params:  dataFilename      = YAML file to parse.
 ///          canonicalFilename = Canonical YAML file used as dummy to determine
 ///                              which data files to load.
-void testEmitterStyles(bool verbose, string dataFilename, string canonicalFilename) @system
+void testEmitterStyles(string dataFilename, string canonicalFilename) @system
 {
     foreach(filename; [dataFilename, canonicalFilename])
     {
@@ -177,7 +174,7 @@ void testEmitterStyles(bool verbose, string dataFilename, string canonicalFilena
                 }
                 auto emitStream = new YMemoryStream;
                 Dumper(emitStream).emit(styledEvents);
-                if(verbose)
+                static if(verbose)
                 {
                     writeln("OUTPUT (", filename, ", ", to!string(flowStyle), ", ",
                             to!string(style), ")");

--- a/source/dyaml/test/errors.d
+++ b/source/dyaml/test/errors.d
@@ -17,9 +17,8 @@ import dyaml.test.common;
 
 /// Loader error unittest from file stream.
 ///
-/// Params:  verbose       = Print verbose output?
-///          errorFilename = File name to read from.
-void testLoaderError(bool verbose, string errorFilename) @safe
+/// Params:  errorFilename = File name to read from.
+void testLoaderError(string errorFilename) @safe
 {
     auto buffer = std.file.read(errorFilename);
 
@@ -27,7 +26,7 @@ void testLoaderError(bool verbose, string errorFilename) @safe
     try { nodes = Loader(buffer).loadAll(); }
     catch(YAMLException e)
     {
-        printException(e, verbose);
+        printException(e);
         return;
     }
     assert(false, "Expected an exception");
@@ -35,9 +34,8 @@ void testLoaderError(bool verbose, string errorFilename) @safe
 
 /// Loader error unittest from string.
 ///
-/// Params:  verbose       = Print verbose output?
-///          errorFilename = File name to read from.
-void testLoaderErrorString(bool verbose, string errorFilename) @safe
+/// Params:  errorFilename = File name to read from.
+void testLoaderErrorString(string errorFilename) @safe
 {
     // Load file to a buffer, then pass that to the YAML loader.
     auto buffer = std.file.read(errorFilename);
@@ -48,7 +46,7 @@ void testLoaderErrorString(bool verbose, string errorFilename) @safe
     }
     catch(YAMLException e)
     {
-        printException(e, verbose);
+        printException(e);
         return;
     }
     assert(false, "Expected an exception");
@@ -56,30 +54,28 @@ void testLoaderErrorString(bool verbose, string errorFilename) @safe
 
 /// Loader error unittest from filename.
 ///
-/// Params:  verbose       = Print verbose output?
-///          errorFilename = File name to read from.
-void testLoaderErrorFilename(bool verbose, string errorFilename) @safe
+/// Params:  errorFilename = File name to read from.
+void testLoaderErrorFilename(string errorFilename) @safe
 {
     try { auto nodes = Loader(errorFilename).loadAll(); }
     catch(YAMLException e)
     {
-        printException(e, verbose);
+        printException(e);
         return;
     }
-    assert(false, "testLoaderErrorSingle(" ~ verbose.to!string ~
-                  ", " ~ errorFilename ~ ") Expected an exception");
+    assert(false, "testLoaderErrorSingle(" ~ ", " ~ errorFilename ~
+                 ") Expected an exception");
 }
 
 /// Loader error unittest loading a single document from a file.
 ///
-/// Params:  verbose       = Print verbose output?
-///          errorFilename = File name to read from.
-void testLoaderErrorSingle(bool verbose, string errorFilename) @safe
+/// Params:  errorFilename = File name to read from.
+void testLoaderErrorSingle(string errorFilename) @safe
 {
     try { auto nodes = Loader(errorFilename).load(); }
     catch(YAMLException e)
     {
-        printException(e, verbose);
+        printException(e);
         return;
     }
     assert(false, "Expected an exception");

--- a/source/dyaml/test/inputoutput.d
+++ b/source/dyaml/test/inputoutput.d
@@ -48,9 +48,8 @@ dchar bom32(bool wrong = false) pure @safe
 
 /// Unicode input unittest. Tests various encodings.
 ///
-/// Params:  verbose         = Print verbose output?
-///          unicodeFilename = File name to read from.
-void testUnicodeInput(bool verbose, string unicodeFilename) @safe
+/// Params:  unicodeFilename = File name to read from.
+void testUnicodeInput(string unicodeFilename) @safe
 {
     string data     = readText(unicodeFilename);
     string expected = data.split().join(" ");
@@ -68,9 +67,8 @@ void testUnicodeInput(bool verbose, string unicodeFilename) @safe
 
 /// Unicode input error unittest. Tests various encodings with incorrect BOMs.
 ///
-/// Params:  verbose         = Print verbose output?
-///          unicodeFilename = File name to read from.
-void testUnicodeInputErrors(bool verbose, string unicodeFilename) @safe
+/// Params:  unicodeFilename = File name to read from.
+void testUnicodeInputErrors(string unicodeFilename) @safe
 {
     string data = readText(unicodeFilename);
     foreach(buffer; [cast(void[])(data.to!(wchar[])),
@@ -81,7 +79,7 @@ void testUnicodeInputErrors(bool verbose, string unicodeFilename) @safe
         try { Loader(buffer).load(); }
         catch(YAMLException e)
         {
-            printException(e, verbose);
+            printException(e);
             continue;
         }
         assert(false, "Expected an exception");

--- a/source/dyaml/test/reader.d
+++ b/source/dyaml/test/reader.d
@@ -16,9 +16,8 @@ import dyaml.reader;
 
 // Try reading entire file through Reader, expecting an error (the file is invalid).
 //
-// Params:  verbose = Print verbose output?
-//          data    = Stream to read.
-void runReader(const bool verbose, ubyte[] fileData) @safe
+// Params:  data    = Stream to read.
+void runReader(ubyte[] fileData) @safe
 {
     try
     {
@@ -27,7 +26,7 @@ void runReader(const bool verbose, ubyte[] fileData) @safe
     }
     catch(ReaderException e)
     {
-        printException(e, verbose);
+        printException(e);
         return;
     }
     assert(false, "Expected an exception");
@@ -36,11 +35,10 @@ void runReader(const bool verbose, ubyte[] fileData) @safe
 
 /// Stream error unittest. Tries to read invalid input files, expecting errors.
 ///
-/// Params:  verbose       = Print verbose output?
-///          errorFilename = File name to read from.
-void testStreamError(bool verbose, string errorFilename) @safe
+/// Params:  errorFilename = File name to read from.
+void testStreamError(string errorFilename) @safe
 {
-    runReader(verbose, readData(errorFilename));
+    runReader(readData(errorFilename));
 }
 
 // TODO: remove when a @safe ubyte[] file read can be done.

--- a/source/dyaml/test/representer.d
+++ b/source/dyaml/test/representer.d
@@ -20,11 +20,10 @@ import dyaml.test.constructor;
 
 /// Representer unittest.
 ///
-/// Params:  verbose      = Print verbose output?
-///          codeFilename = File name to determine test case from.
+/// Params:  codeFilename = File name to determine test case from.
 ///                         Nothing is read from this file, it only exists
 ///                         to specify that we need a matching unittest.
-void testRepresenterTypes(bool verbose, string codeFilename) @safe
+void testRepresenterTypes(string codeFilename) @safe
 {
     string baseName = codeFilename.baseName.stripExtension;
     enforce((baseName in dyaml.test.constructor.expected) !is null,
@@ -38,7 +37,7 @@ void testRepresenterTypes(bool verbose, string codeFilename) @safe
 
         scope(failure)
         {
-            if(verbose)
+            static if(verbose)
             {
                 writeln("Expected nodes:");
                 foreach(ref n; expectedNodes){writeln(n.debugString, "\n---\n");}

--- a/source/dyaml/test/resolver.d
+++ b/source/dyaml/test/resolver.d
@@ -19,11 +19,10 @@ import dyaml.test.common;
 /**
  * Implicit tag resolution unittest.
  *
- * Params:  verbose        = Print verbose output?
- *          dataFilename   = File with unittest data.
+ * Params:  dataFilename   = File with unittest data.
  *          detectFilename = Dummy filename used to specify which data filenames to use.
  */
-void testImplicitResolver(bool verbose, string dataFilename, string detectFilename) @safe
+void testImplicitResolver(string dataFilename, string detectFilename) @safe
 {
     string correctTag;
     Node node;

--- a/source/dyaml/test/tokens.d
+++ b/source/dyaml/test/tokens.d
@@ -20,11 +20,10 @@ import dyaml.token;
 /**
  * Test tokens output by scanner.
  *
- * Params:  verbose        = Print verbose output?
- *          dataFilename   = File to scan.
+ * Params:  dataFilename   = File to scan.
  *          tokensFilename = File containing expected tokens.
  */
-void testTokens(bool verbose, string dataFilename, string tokensFilename) @safe
+void testTokens(string dataFilename, string tokensFilename) @safe
 {
     //representations of YAML tokens in tokens file.
     auto replace = [TokenID.Directive          : "%"   ,
@@ -50,7 +49,7 @@ void testTokens(bool verbose, string dataFilename, string tokensFilename) @safe
     string[] tokens2 = readText(tokensFilename).split();
     scope(exit)
     {
-        if(verbose){writeln("tokens1: ", tokens1, "\ntokens2: ", tokens2);}
+        static if(verbose){writeln("tokens1: ", tokens1, "\ntokens2: ", tokens2);}
     }
 
     auto loader = Loader(dataFilename);
@@ -68,18 +67,17 @@ void testTokens(bool verbose, string dataFilename, string tokensFilename) @safe
 /**
  * Test scanner by scanning a file, expecting no errors.
  *
- * Params:  verbose           = Print verbose output?
- *          dataFilename      = File to scan.
+ * Params:  dataFilename      = File to scan.
  *          canonicalFilename = Another file to scan, in canonical YAML format.
  */
-void testScanner(bool verbose, string dataFilename, string canonicalFilename) @safe
+void testScanner(string dataFilename, string canonicalFilename) @safe
 {
     foreach(filename; [dataFilename, canonicalFilename])
     {
         string[] tokens;
         scope(exit)
         {
-            if(verbose){writeln(tokens);}
+            static if(verbose){writeln(tokens);}
         }
         auto loader = Loader(filename);
         foreach(ref token; loader.scan()){tokens ~= to!string(token.id);}


### PR DESCRIPTION
Now we can enable verbose test output just by specifying `-d verbose` with dub.