### PR TITLE
allow @safe access to anchor/tag/tagDirectives of events

### DIFF
--- a/source/dyaml/composer.d
+++ b/source/dyaml/composer.d
@@ -174,7 +174,7 @@ final class Composer
         ///
         /// Params: pairAppenderLevel = Current level of the pair appender stack.
         ///         nodeAppenderLevel = Current level of the node appender stack.
-        Node composeNode(const uint pairAppenderLevel, const uint nodeAppenderLevel) @system
+        Node composeNode(const uint pairAppenderLevel, const uint nodeAppenderLevel) @safe
         {
             if(parser_.checkEvent(EventID.Alias))
             {
@@ -249,7 +249,7 @@ final class Composer
         /// Params: pairAppenderLevel = Current level of the pair appender stack.
         ///         nodeAppenderLevel = Current level of the node appender stack.
         Node composeSequenceNode(const uint pairAppenderLevel, const uint nodeAppenderLevel)
-            @system
+            @safe
         {
             ensureAppendersExist(pairAppenderLevel, nodeAppenderLevel);
             auto nodeAppender = &(nodeAppenders_[nodeAppenderLevel]);
@@ -346,7 +346,7 @@ final class Composer
         /// Params: pairAppenderLevel = Current level of the pair appender stack.
         ///         nodeAppenderLevel = Current level of the node appender stack.
         Node composeMappingNode(const uint pairAppenderLevel, const uint nodeAppenderLevel)
-            @system
+            @safe
         {
             ensureAppendersExist(pairAppenderLevel, nodeAppenderLevel);
             immutable startEvent = parser_.getEvent();

--- a/source/dyaml/emitter.d
+++ b/source/dyaml/emitter.d
@@ -480,7 +480,7 @@ struct Emitter
             }
         }
         ///Handle an alias.
-        void expectAlias() @trusted
+        void expectAlias() @safe
         {
             enforce(event_.anchor !is null, new EmitterException("Anchor is not specified for alias"));
             processAnchor("*");
@@ -681,7 +681,7 @@ struct Emitter
         }
 
         ///Check if an empty document is next.
-        bool checkEmptyDocument() const @trusted pure nothrow
+        bool checkEmptyDocument() const @safe pure nothrow
         {
             if(event_.id != EventID.DocumentStart || events_.length == 0)
             {
@@ -695,7 +695,7 @@ struct Emitter
         }
 
         ///Check if a simple key is next.
-        bool checkSimpleKey() @trusted
+        bool checkSimpleKey() @safe
         {
             uint length = 0;
             const id = event_.id;
@@ -764,7 +764,7 @@ struct Emitter
         }
 
         ///Process and write an anchor/alias.
-        void processAnchor(const string indicator) @trusted
+        void processAnchor(const string indicator) @safe
         {
             if(event_.anchor is null)
             {
@@ -784,7 +784,7 @@ struct Emitter
         }
 
         ///Process and write a tag.
-        void processTag() @trusted
+        void processTag() @safe
         {
             string tag = event_.tag;
 

--- a/source/dyaml/event.d
+++ b/source/dyaml/event.d
@@ -58,13 +58,13 @@ struct Event
         struct
         {
             ///Anchor of the event, if any.
-            string anchor;
+            string _anchor;
             ///Tag of the event, if any.
-            string tag;
+            string _tag;
         }
         ///Tag directives, if this is a DocumentStart.
         //TagDirectives tagDirectives;
-        TagDirective[] tagDirectives;
+        TagDirective[] _tagDirectives;
     }
     ///Event type.
     EventID id = EventID.Invalid;
@@ -94,6 +94,21 @@ struct Event
     ///Get string representation of the token ID.
     @property string idString() const @safe {return to!string(id);}
 
+    auto ref anchor() inout @trusted pure {
+        assert(id != EventID.DocumentStart, "DocumentStart events cannot have anchors.");
+        return _anchor;
+    }
+
+    auto ref tag() inout @trusted pure {
+        assert(id != EventID.DocumentStart, "DocumentStart events cannot have tags.");
+        return _tag;
+    }
+
+    auto ref tagDirectives() inout @trusted pure {
+        assert(id == EventID.DocumentStart, "Only DocumentStart events have tag directives.");
+        return _tagDirectives;
+    }
+
     static assert(Event.sizeof <= 64, "Event struct larger than expected");
 }
 
@@ -105,7 +120,7 @@ struct Event
  *          anchor   = Anchor, if this is an alias event.
  */
 Event event(EventID id)(const Mark start, const Mark end, const string anchor = null)
-    @trusted
+    @safe
 {
     Event result;
     result.startMark = start;
@@ -127,7 +142,7 @@ Event event(EventID id)(const Mark start, const Mark end, const string anchor = 
  */
 Event collectionStartEvent(EventID id)
     (const Mark start, const Mark end, const string anchor, const string tag,
-     const bool implicit, const CollectionStyle style) pure @trusted nothrow
+     const bool implicit, const CollectionStyle style) pure @safe nothrow
 {
     static assert(id == EventID.SequenceStart || id == EventID.SequenceEnd ||
                   id == EventID.MappingStart || id == EventID.MappingEnd);
@@ -180,7 +195,7 @@ alias collectionStartEvent!(EventID.MappingStart)  mappingStartEvent;
  *          tagDirectives = Tag directives of the document.
  */
 Event documentStartEvent(const Mark start, const Mark end, const bool explicit, string YAMLVersion,
-                         TagDirective[] tagDirectives) pure @trusted nothrow
+                         TagDirective[] tagDirectives) pure @safe nothrow
 {
     Event result;
     result.value            = YAMLVersion;
@@ -220,7 +235,7 @@ Event documentEndEvent(const Mark start, const Mark end, const bool explicit) pu
 ///          style    = Scalar style.
 Event scalarEvent(const Mark start, const Mark end, const string anchor, const string tag,
                   const Tuple!(bool, bool) implicit, const string value,
-                  const ScalarStyle style = ScalarStyle.Invalid) @trusted pure nothrow @nogc
+                  const ScalarStyle style = ScalarStyle.Invalid) @safe pure nothrow @nogc
 {
     Event result;
     result.value       = value;


### PR DESCRIPTION
Pretty simple fix. Just added some small inline-able methods to Event that guarantee incorrect fields aren't being inappropriately accessed.

Allows some `@system` and `@trusted` functions to be promoted to `@safe` functions.