### PR TITLE
remove Node.rawNode and just use the constructor instead

### DIFF
--- a/source/dyaml/constructor.d
+++ b/source/dyaml/constructor.d
@@ -291,13 +291,17 @@ final class Constructor
             {
                 static if(is(U : ScalarStyle))
                 {
-                    return Node.rawNode((*delegates!T)[tag](node), start, tag,
-                                        style, CollectionStyle.Invalid);
+                    auto newNode = Node((*delegates!T)[tag](node), tag);
+                    newNode.startMark_ = start;
+                    newNode.scalarStyle = style;
+                    return newNode;
                 }
                 else static if(is(U : CollectionStyle))
                 {
-                    return Node.rawNode((*delegates!T)[tag](node), start, tag,
-                                        ScalarStyle.Invalid, style);
+                    auto newNode = Node((*delegates!T)[tag](node), tag);
+                    newNode.startMark_ = start;
+                    newNode.collectionStyle = style;
+                    return newNode;
                 }
                 else static assert(false);
             }

--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -193,7 +193,7 @@ struct Node
                            Value.allowed!T;
         }
 
-    private:
+    package:
         // Stored value.
         Value value_;
         // Start position of the node.
@@ -1766,28 +1766,6 @@ struct Node
         }
 
     package:
-        // Construct a node from raw data.
-        //
-        // Params:  value           = Value of the node.
-        //          startMark       = Start position of the node in file.
-        //          tag             = Tag of the node.
-        //          scalarStyle     = Scalar style of the node.
-        //          collectionStyle = Collection style of the node.
-        //
-        // Returns: Constructed node.
-        static Node rawNode(Value value, const Mark startMark, const string tag,
-                            const ScalarStyle scalarStyle,
-                            const CollectionStyle collectionStyle) @safe
-        {
-            Node node;
-            node.setValue(value);
-            node.startMark_      = startMark;
-            node.tag_            = tag;
-            node.scalarStyle     = scalarStyle;
-            node.collectionStyle = collectionStyle;
-
-            return node;
-        }
 
         // Construct Node.Value from user defined type.
         static Value userValue(T)(T value) @trusted

--- a/source/dyaml/representer.d
+++ b/source/dyaml/representer.d
@@ -238,11 +238,12 @@ final class Representer
          * Returns: The represented node.
          */
         Node representScalar(string tag, string scalar,
-                             ScalarStyle style = ScalarStyle.Invalid) @trusted
+                             ScalarStyle style = ScalarStyle.Invalid) @safe
         {
             if(style == ScalarStyle.Invalid){style = defaultScalarStyle_;}
-            return Node.rawNode(Node.Value(scalar), Mark(), tag, style,
-                                CollectionStyle.Invalid);
+            auto newNode = Node(scalar, tag);
+            newNode.scalarStyle = style;
+            return newNode;
         }
         ///
         @safe unittest
@@ -291,7 +292,7 @@ final class Representer
          * Throws:  $(D RepresenterException) if a child could not be represented.
          */
         Node representSequence(string tag, Node[] sequence,
-                               CollectionStyle style = CollectionStyle.Invalid) @trusted
+                               CollectionStyle style = CollectionStyle.Invalid) @safe
         {
             Node[] value;
             value.length = sequence.length;
@@ -314,8 +315,9 @@ final class Representer
                         ? defaultCollectionStyle_
                         : bestStyle;
             }
-            return Node.rawNode(Node.Value(value), Mark(), tag,
-                                ScalarStyle.Invalid, style);
+            auto newNode = Node(value, tag);
+            newNode.collectionStyle = style;
+            return newNode;
         }
         ///
         @safe unittest
@@ -365,7 +367,7 @@ final class Representer
          * Throws:  $(D RepresenterException) if a child could not be represented.
          */
         Node representMapping(string tag, Node.Pair[] pairs,
-                              CollectionStyle style = CollectionStyle.Invalid) @trusted
+                              CollectionStyle style = CollectionStyle.Invalid) @safe
         {
             Node.Pair[] value;
             value.length = pairs.length;
@@ -396,8 +398,9 @@ final class Representer
                         ? defaultCollectionStyle_
                         : bestStyle;
             }
-            return Node.rawNode(Node.Value(value), Mark(), tag,
-                                ScalarStyle.Invalid, style);
+            auto newNode = Node(value, tag);
+            newNode.collectionStyle = style;
+            return newNode;
         }
         ///
         @safe unittest


### PR DESCRIPTION
Instead of using Node.rawNode, which requires usage of un`@safe` code, just use the constructor and set the style/mark manually. No perceivable performance change.