### PR TITLE
remove useless buildTypes block from dub.json

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,12 +7,5 @@
     "license": "Boost 1.0",
     "dependencies": { "tinyendian" : { "version" : "~>0.1.0" } },
     "homepage": "https://github.com/dlang-community/D-YAML",
-    "copyright": "Copyright © 2011-2014, Ferdinand Majerech",
-
-    "buildTypes":
-    {
-        "debug": { "buildOptions": ["debugMode"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline", "noBoundsCheck"] },
-        "profile": { "buildOptions": ["releaseMode", "optimize", "noBoundsCheck"] }
-    }
+    "copyright": "Copyright © 2011-2014, Ferdinand Majerech"
 }


### PR DESCRIPTION
This is mostly redundant and the noboundscheck option doesn't really help here, judging from the benchmarking results.