### PR TITLE
make Loader interface a bit more consistent

### DIFF
--- a/examples/constructor/main.d
+++ b/examples/constructor/main.d
@@ -78,7 +78,7 @@ void main()
        constructor.addConstructorScalar("!color", &constructColorScalar);
        constructor.addConstructorMapping("!color-mapping", &constructColorMapping);
 
-       auto loader = Loader("input.yaml");
+       auto loader = Loader.fromFile("input.yaml");
        loader.constructor = constructor;
 
        auto root = loader.load();

--- a/examples/getting_started/main.d
+++ b/examples/getting_started/main.d
@@ -4,7 +4,7 @@ import dyaml;
 void main()
 {
     //Read the input.
-    Node root = Loader("input.yaml").load();
+    Node root = Loader.fromFile("input.yaml").load();
 
     //Display the data read.
     foreach(string word; root["Hello World"])

--- a/examples/resolver/main.d
+++ b/examples/resolver/main.d
@@ -83,7 +83,7 @@ void main()
        resolver.addImplicitResolver("!color", std.regex.regex("[0-9a-fA-F]{6}"),
                                     "0123456789abcdefABCDEF");
 
-       auto loader = Loader("input.yaml");
+       auto loader = Loader.fromFile("input.yaml");
        loader.constructor = constructor;
        loader.resolver = resolver;
 

--- a/examples/yaml_bench/yaml_bench.d
+++ b/examples/yaml_bench/yaml_bench.d
@@ -104,7 +104,7 @@ void main(string[] args) //@safe
             else       { fileWorkingCopy[] = fileInMemory[]; }
             void[] fileToLoad = reload ? fileInMemory : fileWorkingCopy;
 
-            auto loader        = Loader(fileToLoad);
+            auto loader        = Loader.fromBuffer(fileToLoad);
             if(scanOnly)
             {
                 loader.scanBench();

--- a/examples/yaml_gen/yaml_gen.d
+++ b/examples/yaml_gen/yaml_gen.d
@@ -264,7 +264,7 @@ Node generateNode(const string type, bool root = false)
 
 Node[] generate(const string configFileName)
 {
-    config = Loader(configFileName).load();
+    config = Loader.fromFile(configFileName).load();
 
     minNodesDocument = config["min-nodes-per-document"].as!long;
 

--- a/examples/yaml_stats/yaml_stats.d
+++ b/examples/yaml_stats/yaml_stats.d
@@ -90,7 +90,7 @@ void main(string[] args)
         writeln("------------------------------------------------------------");
         try
         {
-            auto loader = Loader(file);
+            auto loader = Loader.fromFile(file);
 
             size_t idx = 0;
             foreach(ref document; loader)

--- a/source/dyaml/constructor.d
+++ b/source/dyaml/constructor.d
@@ -170,7 +170,7 @@ final class Constructor
                 return MyStruct(to!int(parts[0]), to!int(parts[1]), to!int(parts[2]));
             }
 
-            auto loader = Loader.fromString("!mystruct 12:34:56".dup);
+            auto loader = Loader.fromString("!mystruct 12:34:56");
             auto constructor = new Constructor;
             constructor.addConstructorScalar("!mystruct", &constructMyStructScalar);
             loader.constructor = constructor;
@@ -211,7 +211,7 @@ final class Constructor
                  //!mystruct [x, y, z]
                  return MyStruct(node[0].as!int, node[1].as!int, node[2].as!int);
              }
-             auto loader = Loader.fromString("!mystruct [1,2,3]".dup);
+             auto loader = Loader.fromString("!mystruct [1,2,3]");
              auto constructor = new Constructor;
              constructor.addConstructorSequence("!mystruct", &constructMyStructSequence);
              loader.constructor = constructor;
@@ -252,7 +252,7 @@ final class Constructor
                 //!mystruct {"x": x, "y": y, "z": z}
                 return MyStruct(node["x"].as!int, node["y"].as!int, node["z"].as!int);
             }
-            auto loader = Loader.fromString(`!mystruct {"x": 11, "y": 22, "z": 33}`.dup);
+            auto loader = Loader.fromString(`!mystruct {"x": 11, "y": 22, "z": 33}`);
             auto constructor = new Constructor;
             constructor.addConstructorMapping("!mystruct", &constructMyStructMapping);
             loader.constructor = constructor;
@@ -847,8 +847,8 @@ MyStruct constructMyStructMapping(ref Node node) @safe
 
 @safe unittest
 {
-    char[] data = "!mystruct 1:2:3".dup;
-    auto loader = Loader(data);
+    string data = "!mystruct 1:2:3";
+    auto loader = Loader.fromString(data);
     auto constructor = new Constructor;
     constructor.addConstructorScalar("!mystruct", &constructMyStructScalar);
     loader.constructor = constructor;
@@ -859,8 +859,8 @@ MyStruct constructMyStructMapping(ref Node node) @safe
 
 @safe unittest
 {
-    char[] data = "!mystruct [1, 2, 3]".dup;
-    auto loader = Loader(data);
+    string data = "!mystruct [1, 2, 3]";
+    auto loader = Loader.fromString(data);
     auto constructor = new Constructor;
     constructor.addConstructorSequence("!mystruct", &constructMyStructSequence);
     loader.constructor = constructor;
@@ -871,8 +871,8 @@ MyStruct constructMyStructMapping(ref Node node) @safe
 
 @safe unittest
 {
-    char[] data = "!mystruct {x: 1, y: 2, z: 3}".dup;
-    auto loader = Loader(data);
+    string data = "!mystruct {x: 1, y: 2, z: 3}";
+    auto loader = Loader.fromString(data);
     auto constructor = new Constructor;
     constructor.addConstructorMapping("!mystruct", &constructMyStructMapping);
     loader.constructor = constructor;

--- a/source/dyaml/hacks.d
+++ b/source/dyaml/hacks.d
@@ -30,7 +30,7 @@ ScalarStyle scalarStyleHack(ref const(Node) node) @safe nothrow
 @safe unittest
 {
     import dyaml;
-    Node node = Loader.fromString(`"42"`.dup).load(); // loaded from a file
+    Node node = Loader.fromString(`"42"`).load(); // loaded from a file
     if(node.isScalar)
     {
         assert(node.scalarStyleHack() == ScalarStyle.DoubleQuoted);

--- a/source/dyaml/resolver.d
+++ b/source/dyaml/resolver.d
@@ -113,7 +113,7 @@ final class Resolver
 
             write("example.yaml", "A");
 
-            auto loader = Loader("example.yaml");
+            auto loader = Loader.fromFile("example.yaml");
             auto resolver = new Resolver();
             resolver.addImplicitResolver("!tag", regex("A.*"), "A");
             loader.resolver = resolver;

--- a/source/dyaml/stream.d
+++ b/source/dyaml/stream.d
@@ -96,8 +96,8 @@ class YFile : YStream
     import dyaml.dumper, dyaml.loader, dyaml.node;
     import std.file : readText, remove;
 
-    char[] test =  ("Hello World : [Hello, World]\n" ~
-                    "Answer: 42").dup;
+    string test =  "Hello World : [Hello, World]\n" ~
+                    "Answer: 42";
     //Read the input.
     Node expected = Loader.fromString(test).load();
     assert(expected["Hello World"][0] == "Hello");
@@ -108,7 +108,7 @@ class YFile : YStream
     Dumper("output.yaml").dump(expected);
 
     // Load the file and verify that it was saved correctly.
-    Node actual = Loader("output.yaml").load();
+    Node actual = Loader.fromFile("output.yaml").load();
     assert(actual["Hello World"][0] == "Hello");
     assert(actual["Hello World"][1] == "World");
     assert(actual["Answer"].as!int == 42);
@@ -128,7 +128,7 @@ class YFile : YStream
 
     auto dumper = Dumper(fn);
     dumper.YAMLVersion = null; // supress directive
-    dumper.dump(Loader.fromString("Hello world".dup).load);
+    dumper.dump(Loader.fromString("Hello world").load);
 
     assert (fn.read()[0..3] == "Hel");
 }

--- a/source/dyaml/test/compare.d
+++ b/source/dyaml/test/compare.d
@@ -20,8 +20,8 @@ import dyaml.token;
 ///          canonicalFilename = Another file to parse, in canonical YAML format.
 void testParser(string dataFilename, string canonicalFilename) @safe
 {
-    auto dataEvents = Loader(dataFilename).parse();
-    auto canonicalEvents = Loader(canonicalFilename).parse();
+    auto dataEvents = Loader.fromFile(dataFilename).parse();
+    auto canonicalEvents = Loader.fromFile(canonicalFilename).parse();
 
     assert(dataEvents.length == canonicalEvents.length);
 
@@ -38,8 +38,8 @@ void testParser(string dataFilename, string canonicalFilename) @safe
 ///          canonicalFilename = Another file to load, in canonical YAML format.
 void testLoader(string dataFilename, string canonicalFilename) @safe
 {
-    auto data = Loader(dataFilename).loadAll();
-    auto canonical = Loader(canonicalFilename).loadAll();
+    auto data = Loader.fromFile(dataFilename).loadAll();
+    auto canonical = Loader.fromFile(canonicalFilename).loadAll();
 
     assert(data.length == canonical.length, "Unequal node count");
     foreach(n; 0 .. data.length)

--- a/source/dyaml/test/constructor.d
+++ b/source/dyaml/test/constructor.d
@@ -407,7 +407,7 @@ void testConstructor(string dataFilename, string codeDummy) @safe
     constructor.addConstructorMapping("!tag1", &constructClass);
     constructor.addConstructorScalar("!tag2", &constructStruct);
 
-    auto loader        = Loader(dataFilename);
+    auto loader        = Loader.fromFile(dataFilename);
     loader.constructor = constructor;
     loader.resolver    = new Resolver;
 

--- a/source/dyaml/test/emitter.d
+++ b/source/dyaml/test/emitter.d
@@ -81,7 +81,7 @@ bool compareEvents(Event[] events1, Event[] events2) @system
 void testEmitterOnData(string dataFilename, string canonicalFilename) @system
 {
     //Must exist due to Anchor, Tags reference counts.
-    auto loader = Loader(dataFilename);
+    auto loader = Loader.fromFile(dataFilename);
     auto events = cast(Event[])loader.parse();
     auto emitStream = new YMemoryStream;
     Dumper(emitStream).emit(events);
@@ -93,7 +93,7 @@ void testEmitterOnData(string dataFilename, string canonicalFilename) @system
         writeln("OUTPUT:\n", cast(string)emitStream.data);
     }
 
-    auto loader2        = Loader(emitStream.data.dup);
+    auto loader2        = Loader.fromBuffer(emitStream.data);
     loader2.name        = "TEST";
     loader2.constructor = new Constructor;
     loader2.resolver    = new Resolver;
@@ -109,7 +109,7 @@ void testEmitterOnData(string dataFilename, string canonicalFilename) @system
 void testEmitterOnCanonical(string canonicalFilename) @system
 {
     //Must exist due to Anchor, Tags reference counts.
-    auto loader = Loader(canonicalFilename);
+    auto loader = Loader.fromFile(canonicalFilename);
     auto events = cast(Event[])loader.parse();
     foreach(canonical; [false, true])
     {
@@ -122,7 +122,7 @@ void testEmitterOnCanonical(string canonicalFilename) @system
             writeln("OUTPUT (canonical=", canonical, "):\n",
                     cast(string)emitStream.data);
         }
-        auto loader2        = Loader(emitStream.data.dup);
+        auto loader2        = Loader.fromBuffer(emitStream.data);
         loader2.name        = "TEST";
         loader2.constructor = new Constructor;
         loader2.resolver    = new Resolver;
@@ -143,7 +143,7 @@ void testEmitterStyles(string dataFilename, string canonicalFilename) @system
     foreach(filename; [dataFilename, canonicalFilename])
     {
         //must exist due to Anchor, Tags reference counts
-        auto loader = Loader(canonicalFilename);
+        auto loader = Loader.fromFile(canonicalFilename);
         auto events = cast(Event[])loader.parse();
         foreach(flowStyle; [CollectionStyle.Block, CollectionStyle.Flow])
         {
@@ -180,7 +180,7 @@ void testEmitterStyles(string dataFilename, string canonicalFilename) @system
                             to!string(style), ")");
                     writeln(emitStream.data);
                 }
-                auto loader2        = Loader(emitStream.data.dup);
+                auto loader2        = Loader.fromBuffer(emitStream.data);
                 loader2.name        = "TEST";
                 loader2.constructor = new Constructor;
                 loader2.resolver    = new Resolver;

--- a/source/dyaml/test/errors.d
+++ b/source/dyaml/test/errors.d
@@ -20,10 +20,8 @@ import dyaml.test.common;
 /// Params:  errorFilename = File name to read from.
 void testLoaderError(string errorFilename) @safe
 {
-    auto buffer = std.file.read(errorFilename);
-
     Node[] nodes;
-    try { nodes = Loader(buffer).loadAll(); }
+    try { nodes = Loader.fromFile(errorFilename).loadAll(); }
     catch(YAMLException e)
     {
         printException(e);
@@ -37,12 +35,9 @@ void testLoaderError(string errorFilename) @safe
 /// Params:  errorFilename = File name to read from.
 void testLoaderErrorString(string errorFilename) @safe
 {
-    // Load file to a buffer, then pass that to the YAML loader.
-    auto buffer = std.file.read(errorFilename);
-
     try
     {
-        auto nodes = Loader(buffer).loadAll();
+        auto nodes = Loader.fromFile(errorFilename).loadAll();
     }
     catch(YAMLException e)
     {
@@ -57,7 +52,7 @@ void testLoaderErrorString(string errorFilename) @safe
 /// Params:  errorFilename = File name to read from.
 void testLoaderErrorFilename(string errorFilename) @safe
 {
-    try { auto nodes = Loader(errorFilename).loadAll(); }
+    try { auto nodes = Loader.fromFile(errorFilename).loadAll(); }
     catch(YAMLException e)
     {
         printException(e);
@@ -72,7 +67,7 @@ void testLoaderErrorFilename(string errorFilename) @safe
 /// Params:  errorFilename = File name to read from.
 void testLoaderErrorSingle(string errorFilename) @safe
 {
-    try { auto nodes = Loader(errorFilename).load(); }
+    try { auto nodes = Loader.fromFile(errorFilename).load(); }
     catch(YAMLException e)
     {
         printException(e);

--- a/source/dyaml/test/inputoutput.d
+++ b/source/dyaml/test/inputoutput.d
@@ -54,13 +54,13 @@ void testUnicodeInput(string unicodeFilename) @safe
     string data     = readText(unicodeFilename);
     string expected = data.split().join(" ");
 
-    Node output = Loader(cast(void[])data.to!(char[])).load();
+    Node output = Loader.fromBuffer(cast(ubyte[])data.to!(char[])).load();
     assert(output.as!string == expected);
 
-    foreach(buffer; [cast(void[])(bom16() ~ data.to!(wchar[])),
-                     cast(void[])(bom32() ~ data.to!(dchar[]))])
+    foreach(buffer; [cast(ubyte[])(bom16() ~ data.to!(wchar[])),
+                     cast(ubyte[])(bom32() ~ data.to!(dchar[]))])
     {
-        output = Loader(buffer).load();
+        output = Loader.fromBuffer(buffer).load();
         assert(output.as!string == expected);
     }
 }
@@ -71,12 +71,12 @@ void testUnicodeInput(string unicodeFilename) @safe
 void testUnicodeInputErrors(string unicodeFilename) @safe
 {
     string data = readText(unicodeFilename);
-    foreach(buffer; [cast(void[])(data.to!(wchar[])),
-                     cast(void[])(data.to!(dchar[])),
-                     cast(void[])(bom16(true) ~ data.to!(wchar[])),
-                     cast(void[])(bom32(true) ~ data.to!(dchar[]))])
+    foreach(buffer; [cast(ubyte[])(data.to!(wchar[])),
+                     cast(ubyte[])(data.to!(dchar[])),
+                     cast(ubyte[])(bom16(true) ~ data.to!(wchar[])),
+                     cast(ubyte[])(bom32(true) ~ data.to!(dchar[]))])
     {
-        try { Loader(buffer).load(); }
+        try { Loader.fromBuffer(buffer).load(); }
         catch(YAMLException e)
         {
             printException(e);

--- a/source/dyaml/test/representer.d
+++ b/source/dyaml/test/representer.d
@@ -65,7 +65,7 @@ void testRepresenterTypes(string codeFilename) @safe
         constructor.addConstructorMapping("!tag1", &constructClass);
         constructor.addConstructorScalar("!tag2", &constructStruct);
 
-        auto loader        = Loader(emitStream.data.dup);
+        auto loader        = Loader.fromBuffer(emitStream.data);
         loader.name        = "TEST";
         loader.constructor = constructor;
         readNodes          = loader.loadAll();

--- a/source/dyaml/test/resolver.d
+++ b/source/dyaml/test/resolver.d
@@ -37,7 +37,7 @@ void testImplicitResolver(string dataFilename, string detectFilename) @safe
     }
 
     correctTag = readText(detectFilename).strip();
-    node = Loader(dataFilename).load();
+    node = Loader.fromFile(dataFilename).load();
     assert(node.isSequence);
     foreach(ref Node scalar; node)
     {

--- a/source/dyaml/test/tokens.d
+++ b/source/dyaml/test/tokens.d
@@ -52,7 +52,7 @@ void testTokens(string dataFilename, string tokensFilename) @safe
         static if(verbose){writeln("tokens1: ", tokens1, "\ntokens2: ", tokens2);}
     }
 
-    auto loader = Loader(dataFilename);
+    auto loader = Loader.fromFile(dataFilename);
     foreach(token; loader.scan())
     {
         if(token.id != TokenID.StreamStart && token.id != TokenID.StreamEnd)
@@ -79,7 +79,7 @@ void testScanner(string dataFilename, string canonicalFilename) @safe
         {
             static if(verbose){writeln(tokens);}
         }
-        auto loader = Loader(filename);
+        auto loader = Loader.fromFile(filename);
         foreach(ref token; loader.scan()){tokens ~= to!string(token.id);}
     }
 }


### PR DESCRIPTION
New: `Loader.fromFile(string filename)`, `Loader.fromBuffer(ubyte/void[])`, `Loader.fromString(string)`
Removed: `Loader(string filename)`
Made private: `Loader(void[])`

We already had `Loader.fromString`, so adding fromFile and fromBuffer just makes things more consistent and clearer for users.

The `Loader.fromString(string)` overload is added for simplification. There was already a documented way to pass a `string` so we might as well minimize the work for the users where we can.

I'm sure there will be nits to pick, so go nuts.