### PR TITLE
only build dyaml:benchmark once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ script:
   - "dub build dyaml:getting-started"
   - "dub build dyaml:representer"
   - "dub build dyaml:resolver"
-  - "dub build dyaml:benchmark"
   - "dub build dyaml:yaml_gen"
   - "dub build dyaml:yaml_stats"
   - dub test --build=unittest-cov


### PR DESCRIPTION
I seem to have accidentally snuck an extra build of dyaml:benchmark in when adding examples to travis-ci's script. oooooops.