### PR TITLE
make Constructor wholly @safe

### DIFF
--- a/examples/constructor/main.d
+++ b/examples/constructor/main.d
@@ -17,7 +17,7 @@ struct Color
    }
 }
 
-Color constructColorScalar(ref Node node)
+Color constructColorScalar(ref Node node) @safe
 {
     string value = node.as!string;
 
@@ -52,7 +52,7 @@ Color constructColorScalar(ref Node node)
     return result;
 }
 
-Color constructColorMapping(ref Node node)
+Color constructColorMapping(ref Node node) @safe
 {
     ubyte r,g,b;
 

--- a/examples/resolver/main.d
+++ b/examples/resolver/main.d
@@ -17,7 +17,7 @@ struct Color
    }
 }
 
-Color constructColorScalar(ref Node node)
+Color constructColorScalar(ref Node node) @safe
 {
     string value = node.as!string;
 
@@ -52,7 +52,7 @@ Color constructColorScalar(ref Node node)
     return result;
 }
 
-Color constructColorMapping(ref Node node)
+Color constructColorMapping(ref Node node) @safe
 {
     ubyte r,g,b;
 

--- a/source/dyaml/constructor.d
+++ b/source/dyaml/constructor.d
@@ -64,11 +64,11 @@ final class Constructor
 {
     private:
         // Constructor functions from scalars.
-        Node.Value delegate(ref Node)[string] fromScalar_;
+        Node delegate(ref Node) @safe[string] fromScalar_;
         // Constructor functions from sequences.
-        Node.Value delegate(ref Node)[string] fromSequence_;
+        Node delegate(ref Node) @safe[string] fromSequence_;
         // Constructor functions from mappings.
-        Node.Value delegate(ref Node)[string] fromMapping_;
+        Node delegate(ref Node) @safe[string] fromMapping_;
 
     public:
         /// Construct a Constructor.
@@ -138,7 +138,7 @@ final class Constructor
          * Params:  tag  = Tag for the function to handle.
          *          ctor = Constructor function.
          */
-        void addConstructorScalar(T)(const string tag, T function(ref Node) ctor)
+        void addConstructorScalar(T)(const string tag, T function(ref Node) @safe ctor)
         {
             const t = tag;
             auto deleg = addConstructor!T(t, ctor);
@@ -183,7 +183,7 @@ final class Constructor
          *
          * See_Also:    addConstructorScalar
          */
-        void addConstructorSequence(T)(const string tag, T function(ref Node) ctor)
+        void addConstructorSequence(T)(const string tag, T function(ref Node) @safe ctor)
         {
             const t = tag;
             auto deleg = addConstructor!T(t, ctor);
@@ -224,7 +224,7 @@ final class Constructor
          *
          * See_Also:    addConstructorScalar
          */
-        void addConstructorMapping(T)(const string tag, T function(ref Node) ctor)
+        void addConstructorMapping(T)(const string tag, T function(ref Node) @safe ctor)
         {
             const t = tag;
             auto deleg = addConstructor!T(t, ctor);
@@ -274,7 +274,7 @@ final class Constructor
          * Returns: Constructed node.
          */
         Node node(T, U)(const Mark start, const Mark end, const string tag,
-                        T value, U style) @trusted
+                        T value, U style) @safe
             if((is(T : string) || is(T == Node[]) || is(T == Node.Pair[])) &&
                (is(U : CollectionStyle) || is(U : ScalarStyle)))
         {
@@ -291,14 +291,14 @@ final class Constructor
             {
                 static if(is(U : ScalarStyle))
                 {
-                    auto newNode = Node((*delegates!T)[tag](node), tag);
+                    auto newNode = (*delegates!T)[tag](node);
                     newNode.startMark_ = start;
                     newNode.scalarStyle = style;
                     return newNode;
                 }
                 else static if(is(U : CollectionStyle))
                 {
-                    auto newNode = Node((*delegates!T)[tag](node), tag);
+                    auto newNode = (*delegates!T)[tag](node);
                     newNode.startMark_ = start;
                     newNode.collectionStyle = style;
                     return newNode;
@@ -319,7 +319,7 @@ final class Constructor
          * Params:  tag  = Tag for the function to handle.
          *          ctor = Constructor function.
          */
-        auto addConstructor(T)(const string tag, T function(ref Node) ctor)
+        auto addConstructor(T)(const string tag, T function(ref Node) @safe ctor)
         {
             assert((tag in fromScalar_) is null &&
                    (tag in fromSequence_) is null &&
@@ -328,10 +328,9 @@ final class Constructor
                    "specified. Can't specify another one.");
 
 
-            return (ref Node n)
+            return (ref Node n) @safe
             {
-                static if(Node.allowed!T){return Node.value(ctor(n));}
-                else                     {return Node.userValue(ctor(n));}
+                return Node(ctor(n), tag);
             };
         }
 

--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -1767,38 +1767,6 @@ struct Node
 
     package:
 
-        // Construct Node.Value from user defined type.
-        static Value userValue(T)(T value) @trusted
-        {
-            return Value(cast(YAMLObject)new YAMLContainer!T(value));
-        }
-
-        // Construct Node.Value from a type it can store directly (after casting if needed)
-        static Value value(T)(T value) if(allowed!T)
-        {
-            static if(Value.allowed!T)
-            {
-                return Value(value);
-            }
-            else static if(isIntegral!T)
-            {
-                return Value(cast(long)(value));
-            }
-            else static if (is(Unqual!T == bool))
-            {
-                return Value(cast(bool)(value));
-            }
-            else static if(isFloatingPoint!T)
-            {
-                return Value(cast(real)(value));
-            }
-            else static if(isSomeString!T)
-            {
-                return Value(to!string(value));
-            }
-            else static assert(false, "Unknown value type. Is value() in sync with allowed()?");
-        }
-
         // Equality test with any value.
         //
         // useTag determines whether or not to consider tags in node-node comparisons.


### PR DESCRIPTION
Mostly just marking delegates as `@safe` and removing unnecessary dependence on std.variant again.

Also simplifies things somewhat, as a nice bonus.