### PR TITLE
make the unittests much less noisy by default

### DIFF
--- a/source/dyaml/constructor.d
+++ b/source/dyaml/constructor.d
@@ -19,7 +19,6 @@ import std.container;
 import std.conv;
 import std.datetime;
 import std.exception;
-import std.stdio;
 import std.regex;
 import std.string;
 import std.typecons;
@@ -613,8 +612,6 @@ SysTime constructTimestamp(ref Node node) @safe
 }
 @safe unittest
 {
-    writeln("D:YAML construction timestamp unittest");
-
     string timestamp(string value)
     {
         auto node = Node(value);
@@ -682,8 +679,6 @@ Node.Pair[] constructOrderedMap(ref Node node) @safe
 }
 @safe unittest
 {
-    writeln("D:YAML construction ordered map unittest");
-
     alias Node.Pair Pair;
 
     Node[] alternateTypes(uint length) @safe
@@ -750,8 +745,6 @@ Node[] constructSet(ref Node node) @safe
 }
 @safe unittest
 {
-    writeln("D:YAML construction set unittest");
-
     Node.Pair[] set(uint length) @safe
     {
         Node.Pair[] pairs;

--- a/source/dyaml/flags.d
+++ b/source/dyaml/flags.d
@@ -61,9 +61,6 @@ struct Flags(names ...) if(names.length <= 8)
 ///
 @safe unittest
 {
-    import std.stdio;
-    writeln("Flags unittest");
-
     Flags!("empty", "multiline") flags;
     assert(flags.empty == false && flags.multiline == false);
     flags.multiline = true;

--- a/source/dyaml/hacks.d
+++ b/source/dyaml/hacks.d
@@ -7,9 +7,6 @@
 /// Functionality that may sometimes be needed but allows unsafe or unstandard behavior, and should only be used in specific cases.
 module dyaml.hacks;
 
-
-import std.stdio;
-
 import dyaml.node;
 import dyaml.style;
 
@@ -41,7 +38,6 @@ ScalarStyle scalarStyleHack(ref const(Node) node) @safe nothrow
 }
 @safe unittest
 {
-    writeln("D:YAML scalarStyleHack getter unittest");
     auto node = Node(5);
     assert(node.scalarStyleHack() == ScalarStyle.Invalid);
 }
@@ -59,7 +55,6 @@ CollectionStyle collectionStyleHack(ref const(Node) node) @safe nothrow
 }
 @safe unittest
 {
-    writeln("D:YAML collectionStyleHack getter unittest");
     auto node = Node([1, 2, 3, 4, 5]);
     assert(node.collectionStyleHack() == CollectionStyle.Invalid);
 }
@@ -79,7 +74,6 @@ void scalarStyleHack(ref Node node, const ScalarStyle rhs) @safe nothrow
 ///
 @safe unittest
 {
-    writeln("D:YAML scalarStyleHack setter unittest");
     auto node = Node(5);
     node.scalarStyleHack = ScalarStyle.DoubleQuoted;
     assert(node.scalarStyleHack() == ScalarStyle.DoubleQuoted);
@@ -99,7 +93,6 @@ void collectionStyleHack(ref Node node, const CollectionStyle rhs) @safe nothrow
 ///
 @safe unittest
 {
-    writeln("D:YAML collectionStyleHack setter unittest");
     auto node = Node([1, 2, 3, 4, 5]);
     node.collectionStyleHack = CollectionStyle.Block;
     assert(node.collectionStyleHack() == CollectionStyle.Block);

--- a/source/dyaml/loader.d
+++ b/source/dyaml/loader.d
@@ -359,8 +359,7 @@ struct Loader
 
     foreach(string color, string value; colors)
     {
-        import std.stdio;
-        writeln(color, " is ", value, " in HTML/CSS");
+        // Do something with the color and its value...
     }
 }
 

--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -16,7 +16,6 @@ import std.datetime;
 import std.exception;
 import std.math;
 import std.range;
-import std.stdio;
 import std.string;
 import std.traits;
 import std.typecons;
@@ -737,7 +736,6 @@ struct Node
         ///
         @safe unittest
         {
-            writeln("D:YAML Node opIndex unittest");
             alias Node.Value Value;
             alias Node.Pair Pair;
 
@@ -751,7 +749,6 @@ struct Node
         }
         @safe unittest
         {
-            writeln("D:YAML Node opIndex unittest");
             alias Node.Value Value;
             alias Node.Pair Pair;
 
@@ -815,7 +812,6 @@ struct Node
         // Unittest for contains() and containsKey().
         @safe unittest
         {
-            writeln("D:YAML Node contains/containsKey unittest");
             auto seq = Node([1, 2, 3, 4, 5]);
             assert(seq.contains(3));
             assert(seq.contains(5));
@@ -946,8 +942,6 @@ struct Node
         }
         @safe unittest
         {
-            writeln("D:YAML Node opIndexAssign unittest");
-
             with(Node([1, 2, 3, 4, 3]))
             {
                 opIndexAssign(42, 3);
@@ -1067,8 +1061,6 @@ struct Node
         }
         @safe unittest
         {
-            writeln("D:YAML Node sequence unittest");
-
             Node n1 = Node([1, 2, 3, 4]);
             int[int] array;
             Node n2 = Node(array);
@@ -1159,8 +1151,6 @@ struct Node
         }
         @safe unittest
         {
-            writeln("D:YAML Node mapping unittest");
-
             int[int] array;
             Node n = Node(array);
             n[1] = "foo";
@@ -1201,8 +1191,6 @@ struct Node
         }
         @safe unittest
         {
-            writeln("D:YAML Node mappingKeys unittest");
-
             int[int] array;
             Node m1 = Node(array);
             m1["foo"] = 2;
@@ -1235,8 +1223,6 @@ struct Node
         }
         @safe unittest
         {
-            writeln("D:YAML Node mappingValues unittest");
-
             int[int] array;
             Node m1 = Node(array);
             m1["foo"] = 2;
@@ -1324,8 +1310,6 @@ struct Node
          }
         @safe unittest
         {
-            writeln("D:YAML Node opApply unittest 1");
-
             Node n1 = Node(11);
             Node n2 = Node(12);
             Node n3 = Node(13);
@@ -1468,8 +1452,6 @@ struct Node
          }
         @safe unittest
         {
-            writeln("D:YAML Node opApply unittest 2");
-
             alias Node.Value Value;
             alias Node.Pair Pair;
 
@@ -1562,8 +1544,6 @@ struct Node
         }
         @safe unittest
         {
-            writeln("D:YAML Node add unittest 1");
-
             with(Node([1, 2, 3, 4]))
             {
                 add(5.0f);
@@ -1599,7 +1579,6 @@ struct Node
         }
         @safe unittest
         {
-            writeln("D:YAML Node add unittest 2");
             with(Node([1, 2], [3, 4]))
             {
                 add(5, "6");
@@ -1639,7 +1618,6 @@ struct Node
         }
         @safe unittest
         {
-            writeln(`D:YAML Node opBinaryRight!"in" unittest`);
             auto mapping = Node(["foo", "baz"], ["bar", "qux"]);
             assert("bad" !in mapping && ("bad" in mapping) is null);
             Node* foo = "foo" in mapping;
@@ -1677,7 +1655,6 @@ struct Node
         }
         @safe unittest
         {
-            writeln("D:YAML Node remove unittest");
             with(Node([1, 2, 3, 4, 3]))
             {
                 remove(3);
@@ -1725,7 +1702,6 @@ struct Node
         }
         @safe unittest
         {
-            writeln("D:YAML Node removeAt unittest");
             with(Node([1, 2, 3, 4, 3]))
             {
                 removeAt(3);
@@ -1762,7 +1738,8 @@ struct Node
         }
         @safe unittest
         {
-            writeln("Node(42).toHash(): ", Node(42).toHash());
+            assert(Node(42).toHash() != Node(41).toHash());
+            assert(Node(42).toHash() != Node(42, "some-tag").toHash());
         }
 
     package:

--- a/source/dyaml/reader.d
+++ b/source/dyaml/reader.d
@@ -15,7 +15,6 @@ import std.algorithm;
 import std.array;
 import std.conv;
 import std.exception;
-import std.stdio;
 import std.string;
 import std.system;
 import std.typecons;
@@ -975,7 +974,6 @@ size_t countASCII(const(char)[] buffer) @trusted pure nothrow @nogc
 
 void testEndian(R)()
 {
-    writeln(typeid(R).toString() ~ ": endian unittest");
     void endian_test(ubyte[] data, Encoding encoding_expected, Endian endian_expected)
     {
         auto reader = new R(data);
@@ -991,7 +989,6 @@ void testEndian(R)()
 void testPeekPrefixForward(R)()
 {
     import std.encoding;
-    writeln(typeid(R).toString() ~ ": peek/prefix/forward unittest");
     ubyte[] data = bomTable[BOM.utf8].sequence ~ cast(ubyte[])"data";
     auto reader = new R(data);
     assert(reader.peek() == 'd');
@@ -1009,7 +1006,6 @@ void testPeekPrefixForward(R)()
 void testUTF(R)()
 {
     import std.encoding;
-    writeln(typeid(R).toString() ~ ": UTF formats unittest");
     dchar[] data = cast(dchar[])"data";
     void utf_test(T)(T[] data, BOM bom)
     {
@@ -1028,7 +1024,6 @@ void testUTF(R)()
 
 void test1Byte(R)()
 {
-    writeln(typeid(R).toString() ~ ": 1 byte file unittest");
     ubyte[] data = [97];
 
     auto reader = new R(data);

--- a/source/dyaml/resolver.d
+++ b/source/dyaml/resolver.d
@@ -17,7 +17,6 @@ module dyaml.resolver;
 
 import std.conv;
 import std.regex;
-import std.stdio;
 import std.typecons;
 import std.utf;
 
@@ -169,8 +168,6 @@ final class Resolver
         }
         @safe unittest
         {
-            writeln("D:YAML Resolver unittest");
-
             auto resolver = new Resolver();
 
             bool tagMatch(string tag, string[] values) @safe

--- a/source/dyaml/stream.d
+++ b/source/dyaml/stream.d
@@ -57,9 +57,9 @@ class YFile : YStream
 
     @system unittest
     {
-        import std.stdio : stdout;
-        auto stream = new YFile(stdout);
-        stream.write("Test writing to stdout through YFile stream\n");
+        import std.stdio : File;
+        auto stream = new YFile(File.tmpfile);
+        stream.write("Test writing to tmpFile through YFile stream\n");
     }
 
     void writeExact(const void* buffer, size_t size)

--- a/source/dyaml/test/common.d
+++ b/source/dyaml/test/common.d
@@ -24,8 +24,18 @@ import std.typecons;
 
 package:
 
-debug(verbose) enum verbose = true;
-else enum verbose = false;
+debug(verbose)
+{
+    enum verbose = true;
+    enum quiet = false;
+}
+else
+{
+    enum verbose = false;
+    debug(noisy) enum quiet = false;
+    else enum quiet = true;
+}
+
 /**
  * Run an unittest.
  *
@@ -73,6 +83,14 @@ void run(D)(string testName, D testFunction,
 void printException(YAMLException e) @trusted
 {
         static if(verbose) { writeln(typeid(e).toString(), "\n", e); }
+}
+
+void printProgress(T...)(T params) @safe
+{
+    static if(!quiet)
+    {
+        writeln(params);
+    }
 }
 
 private:
@@ -157,7 +175,7 @@ Result execute(D)(const string testName, D testFunction,
         F parameters;
         stringsToTuple!(F.length - 1, F)(parameters, filenames);
         testFunction(parameters);
-        static if(!verbose){write(".");}
+        static if (!quiet){write(".");}
     }
     catch(Throwable e)
     {
@@ -178,7 +196,7 @@ Result execute(D)(const string testName, D testFunction,
  */
 void display(Result[] results) @safe
 {
-    if(results.length > 0 && !verbose){write("\n");}
+    if(results.length > 0 && !verbose && !quiet){write("\n");}
 
     size_t failures = 0;
     size_t errors = 0;
@@ -205,8 +223,8 @@ void display(Result[] results) @safe
     }
 
     //Totals.
-    writeln("===========================================================================");
-    writeln("TESTS: ", results.length);
+    printProgress("===========================================================================");
+    printProgress("TESTS: ", results.length);
     if(failures > 0){writeln("FAILURES: ", failures);}
     if(errors > 0)  {writeln("ERRORS: ", errors);}
 }

--- a/source/dyaml/test/compare.d
+++ b/source/dyaml/test/compare.d
@@ -62,7 +62,7 @@ void testLoader(string dataFilename, string canonicalFilename) @safe
 
 @safe unittest
 {
-    writeln("D:YAML comparison unittest");
+    printProgress("D:YAML comparison unittest");
     run("testParser", &testParser, ["data", "canonical"]);
     run("testLoader", &testLoader, ["data", "canonical"], ["test_loader_skip"]);
 }

--- a/source/dyaml/test/constructor.d
+++ b/source/dyaml/test/constructor.d
@@ -437,7 +437,7 @@ void testConstructor(string dataFilename, string codeDummy) @safe
 
 @safe unittest
 {
-    writeln("D:YAML Constructor unittest");
+    printProgress("D:YAML Constructor unittest");
     run("testConstructor", &testConstructor, ["data", "code"]);
 }
 

--- a/source/dyaml/test/emitter.d
+++ b/source/dyaml/test/emitter.d
@@ -193,7 +193,7 @@ void testEmitterStyles(string dataFilename, string canonicalFilename) @system
 
 @system unittest
 {
-    writeln("D:YAML Emitter unittest");
+    printProgress("D:YAML Emitter unittest");
     run("testEmitterOnData",      &testEmitterOnData,      ["data", "canonical"]);
     run("testEmitterOnCanonical", &testEmitterOnCanonical, ["canonical"]);
     run("testEmitterStyles",      &testEmitterStyles,      ["data", "canonical"]);

--- a/source/dyaml/test/errors.d
+++ b/source/dyaml/test/errors.d
@@ -83,7 +83,7 @@ void testLoaderErrorSingle(string errorFilename) @safe
 
 @safe unittest
 {
-    writeln("D:YAML Errors unittest");
+    printProgress("D:YAML Errors unittest");
     run("testLoaderError",         &testLoaderError,         ["loader-error"]);
     run("testLoaderErrorString",   &testLoaderErrorString,   ["loader-error"]);
     run("testLoaderErrorFilename", &testLoaderErrorFilename, ["loader-error"]);

--- a/source/dyaml/test/inputoutput.d
+++ b/source/dyaml/test/inputoutput.d
@@ -89,7 +89,7 @@ void testUnicodeInputErrors(string unicodeFilename) @safe
 
 @safe unittest
 {
-    writeln("D:YAML I/O unittest");
+    printProgress("D:YAML I/O unittest");
     run("testUnicodeInput", &testUnicodeInput, ["unicode"]);
     run("testUnicodeInputErrors", &testUnicodeInputErrors, ["unicode"]);
 }

--- a/source/dyaml/test/reader.d
+++ b/source/dyaml/test/reader.d
@@ -50,7 +50,7 @@ ubyte[] readData(string filename) @trusted
 
 @safe unittest
 {
-    writeln("D:YAML Reader unittest");
+    printProgress("D:YAML Reader unittest");
     run("testStreamError", &testStreamError, ["stream-error"]);
 }
 

--- a/source/dyaml/test/representer.d
+++ b/source/dyaml/test/representer.d
@@ -80,7 +80,7 @@ void testRepresenterTypes(string codeFilename) @safe
 
 @safe unittest
 {
-    writeln("D:YAML Representer unittest");
+    printProgress("D:YAML Representer unittest");
     run("testRepresenterTypes", &testRepresenterTypes, ["code"]);
 }
 

--- a/source/dyaml/test/resolver.d
+++ b/source/dyaml/test/resolver.d
@@ -49,7 +49,7 @@ void testImplicitResolver(string dataFilename, string detectFilename) @safe
 
 @safe unittest
 {
-    writeln("D:YAML Resolver unittest");
+    printProgress("D:YAML Resolver unittest");
     run("testImplicitResolver", &testImplicitResolver, ["data", "detect"]);
 }
 

--- a/source/dyaml/test/tokens.d
+++ b/source/dyaml/test/tokens.d
@@ -86,7 +86,7 @@ void testScanner(string dataFilename, string canonicalFilename) @safe
 
 @safe unittest
 {
-    writeln("D:YAML tokens unittest");
+    printProgress("D:YAML tokens unittest");
     run("testTokens",  &testTokens, ["data", "tokens"]);
     run("testScanner", &testScanner, ["data", "canonical"]);
 }


### PR DESCRIPTION
Removes all output (except for errors). Compile with either the `noisy` or `verbose` debug specs if you miss hearing the test suite's voice.