### PR TITLE
[WIP] mark std.container.array functions as @safe

### DIFF
--- a/source/dyaml/emitter.d
+++ b/source/dyaml/emitter.d
@@ -167,7 +167,7 @@ struct Emitter
          *          lineBreak = Line break character/s.
          */
         this(YStream stream, const bool canonical, const int indent, const int width,
-             const LineBreak lineBreak) @trusted
+             const LineBreak lineBreak) @safe
         in{assert(stream.writeable, "Can't emit YAML to a non-writable stream");}
         body
         {
@@ -198,7 +198,7 @@ struct Emitter
 
     private:
         ///Pop and return the newest state in states_.
-        void function() @safe popState() @trusted
+        void function() @safe popState() @safe
         {
             enforce(states_.length > 0,
                     new YAMLException("Emitter: Need to pop a state but there are no states left"));
@@ -213,7 +213,7 @@ struct Emitter
         }
 
         ///Pop and return the newest indent in indents_.
-        int popIndent() @trusted
+        int popIndent() @safe
         {
             enforce(indents_.length > 0,
                     new YAMLException("Emitter: Need to pop an indent level but there" ~
@@ -288,7 +288,7 @@ struct Emitter
         }
 
         ///Increase indentation level.
-        void increaseIndent(const Flag!"flow" flow = No.flow, const bool indentless = false) @trusted
+        void increaseIndent(const Flag!"flow" flow = No.flow, const bool indentless = false) @safe
         {
             indents_ ~= indent_;
             if(indent_ == -1)

--- a/source/dyaml/parser.d
+++ b/source/dyaml/parser.d
@@ -134,7 +134,7 @@ final class Parser
 
     public:
         ///Construct a Parser using specified Scanner.
-        this(Scanner scanner) @trusted
+        this(Scanner scanner) @safe
         {
             state_ = &parseStreamStart;
             scanner_ = scanner;
@@ -226,7 +226,7 @@ final class Parser
 
     private:
         ///Pop and return the newest state in states_.
-        Event delegate() @safe popState() @trusted
+        Event delegate() @safe popState() @safe
         {
             enforce(states_.length > 0,
                     new YAMLException("Parser: Need to pop state but no states left to pop"));
@@ -236,7 +236,7 @@ final class Parser
         }
 
         ///Pop and return the newest mark in marks_.
-        Mark popMark() @trusted
+        Mark popMark() @safe
         {
             enforce(marks_.length > 0,
                     new YAMLException("Parser: Need to pop mark but no marks left to pop"));
@@ -260,7 +260,7 @@ final class Parser
         }
 
         /// Parse implicit document start, unless explicit detected: if so, parse explicit.
-        Event parseImplicitDocumentStart() @trusted
+        Event parseImplicitDocumentStart() @safe
         {
             // Parse an implicit document.
             if(!scanner_.checkToken(TokenID.Directive, TokenID.DocumentStart,
@@ -278,7 +278,7 @@ final class Parser
         }
 
         ///Parse explicit document start.
-        Event parseDocumentStart() @trusted
+        Event parseDocumentStart() @safe
         {
             //Parse any extra document end indicators.
             while(scanner_.checkToken(TokenID.DocumentEnd)){scanner_.getToken();}
@@ -654,7 +654,7 @@ final class Parser
         ///block_sequence ::= BLOCK-SEQUENCE-START (BLOCK-ENTRY block_node?)* BLOCK-END
 
         ///Parse an entry of a block sequence. If first is true, this is the first entry.
-        Event parseBlockSequenceEntry(Flag!"first" first)() @trusted
+        Event parseBlockSequenceEntry(Flag!"first" first)() @safe
         {
             static if(first){marks_ ~= scanner_.getToken().startMark;}
 
@@ -688,7 +688,7 @@ final class Parser
         ///indentless_sequence ::= (BLOCK-ENTRY block_node?)+
 
         ///Parse an entry of an indentless sequence.
-        Event parseIndentlessSequenceEntry() @trusted
+        Event parseIndentlessSequenceEntry() @safe
         {
             if(scanner_.checkToken(TokenID.BlockEntry))
             {
@@ -718,7 +718,7 @@ final class Parser
          */
 
         ///Parse a key in a block mapping. If first is true, this is the first key.
-        Event parseBlockMappingKey(Flag!"first" first)() @trusted
+        Event parseBlockMappingKey(Flag!"first" first)() @safe
         {
             static if(first){marks_ ~= scanner_.getToken().startMark;}
 
@@ -751,7 +751,7 @@ final class Parser
         }
 
         ///Parse a value in a block mapping.
-        Event parseBlockMappingValue() @trusted
+        Event parseBlockMappingValue() @safe
         {
             if(scanner_.checkToken(TokenID.Value))
             {
@@ -785,7 +785,7 @@ final class Parser
          */
 
         ///Parse an entry in a flow sequence. If first is true, this is the first entry.
-        Event parseFlowSequenceEntry(Flag!"first" first)() @trusted
+        Event parseFlowSequenceEntry(Flag!"first" first)() @safe
         {
             static if(first){marks_ ~= scanner_.getToken().startMark;}
 
@@ -827,7 +827,7 @@ final class Parser
         }
 
         ///Parse a key in flow context.
-        Event parseFlowKey(in Event delegate() @safe nextState) @trusted
+        Event parseFlowKey(in Event delegate() @safe nextState) @safe
         {
             const token = scanner_.getToken();
 
@@ -850,7 +850,7 @@ final class Parser
 
         ///Parse a mapping value in a flow context.
         Event parseFlowValue(TokenID checkId, in Event delegate() @safe nextState)
-            @trusted
+            @safe
         {
             if(scanner_.checkToken(TokenID.Value))
             {
@@ -893,7 +893,7 @@ final class Parser
          */
 
         ///Parse a key in a flow mapping.
-        Event parseFlowMappingKey(Flag!"first" first)() @trusted
+        Event parseFlowMappingKey(Flag!"first" first)() @safe
         {
             static if(first){marks_ ~= scanner_.getToken().startMark;}
 

--- a/source/dyaml/scanner.d
+++ b/source/dyaml/scanner.d
@@ -411,7 +411,7 @@ final class Scanner
         /// Decrease indentation, removing entries in indents_.
         ///
         /// Params:  column = Current column in the file/stream.
-        void unwindIndent(const int column) @trusted
+        void unwindIndent(const int column) @safe
         {
             if(flowLevel_ > 0)
             {
@@ -446,7 +446,7 @@ final class Scanner
         /// Params:  column = Current column in the file/stream.
         ///
         /// Returns: true if the indentation was increased, false otherwise.
-        bool addIndent(int column) @trusted
+        bool addIndent(int column) @safe
         {
             if(indent_ >= column){return false;}
             indents_ ~= indent_;


### PR DESCRIPTION
These are all functions whose only `@safe`ty issue is std.container.array.Array being unsafe. It is expected that phobos will eventually resolve these issues and enable Array to be used `@safe`ly.

**This will not compile and MUST NOT BE MERGED until the phobos issue is resolved!**