### PR TITLE
allow uninitialized nodes to become sequence/mapping nodes

### DIFF
--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -1534,6 +1534,10 @@ struct Node
          */
         void add(T)(T value)
         {
+            if (!isValid)
+            {
+                setValue(Node[].init);
+            }
             enforce(isSequence(),
                     new NodeException("Trying to add an element to a " ~ nodeTypeString ~ " node", startMark_));
 
@@ -1548,6 +1552,19 @@ struct Node
             {
                 add(5.0f);
                 assert(opIndex(4).as!float == 5.0f);
+            }
+            with(Node())
+            {
+                add(5.0f);
+                assert(opIndex(0).as!float == 5.0f);
+            }
+            with(Node(5.0f))
+            {
+                assertThrown!NodeException(add(5.0f));
+            }
+            with(Node([5.0f : true]))
+            {
+                assertThrown!NodeException(add(5.0f));
             }
         }
 
@@ -1568,6 +1585,10 @@ struct Node
          */
         void add(K, V)(K key, V value)
         {
+            if (!isValid)
+            {
+                setValue(Node.Pair[].init);
+            }
             enforce(isMapping(),
                     new NodeException("Trying to add a key-value pair to a " ~
                               nodeTypeString ~ " node",
@@ -1583,6 +1604,19 @@ struct Node
             {
                 add(5, "6");
                 assert(opIndex(5).as!string == "6");
+            }
+            with(Node())
+            {
+                add(5, "6");
+                assert(opIndex(5).as!string == "6");
+            }
+            with(Node(5.0f))
+            {
+                assertThrown!NodeException(add(5, "6"));
+            }
+            with(Node([5.0f]))
+            {
+                assertThrown!NodeException(add(5, "6"));
             }
         }
 


### PR DESCRIPTION
With this, code like
```D
auto node = Node();
node.add(5, "hello");
```
will now compile and work as expected. Previously, Node would need to be constructed using an (associative) array for this to work.