### PR TITLE
fix mardown table not well displayed on DUB website

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ might be compatibility breaking changes.
 ## Directory structure
 
 | Directory     | Contents                       |
-| ------------- | ------------------------------ |
+|---------------|--------------------------------|
 | `./`          | This README, utility scripts.  |
 | `./doc`       | Documentation.                 |
 | `./docsrc`    | Documentation sources.         |


### PR DESCRIPTION
![dymlmdtbl](https://user-images.githubusercontent.com/16154339/41272439-63da60c6-6e15-11e8-8566-94d02f536e35.png)

It's because the mardown from vibe-d doesn't support spaces at column edges.
The table for tinyendian is okay for example (https://code.dlang.org/packages/tinyendian)
