### PR TITLE
Remove a number of unsafe immutable casts

### DIFF
--- a/source/dyaml/composer.d
+++ b/source/dyaml/composer.d
@@ -180,7 +180,7 @@ final class Composer
         {
             if(parser_.checkEvent(EventID.Alias))
             {
-                immutable event = parser_.getEvent();
+                const event = parser_.getEvent();
                 const anchor = event.anchor;
                 enforce((anchor in anchors_) !is null,
                         new ComposerException("Found undefined alias: " ~ anchor,
@@ -196,7 +196,7 @@ final class Composer
                 return anchors_[anchor];
             }
 
-            immutable event = parser_.peekEvent();
+            const event = parser_.peekEvent();
             const anchor = event.anchor;
             if((anchor !is null) && (anchor in anchors_) !is null)
             {
@@ -236,7 +236,7 @@ final class Composer
         ///Compose a scalar node.
         Node composeScalarNode() @safe
         {
-            immutable event = parser_.getEvent();
+            const event = parser_.getEvent();
             const tag = resolver_.resolve(NodeID.Scalar, event.tag, event.value,
                                           event.implicit);
 
@@ -256,7 +256,7 @@ final class Composer
             ensureAppendersExist(pairAppenderLevel, nodeAppenderLevel);
             auto nodeAppender = &(nodeAppenders_[nodeAppenderLevel]);
 
-            immutable startEvent = parser_.getEvent();
+            const startEvent = parser_.getEvent();
             const tag = resolver_.resolve(NodeID.Sequence, startEvent.tag, null,
                                           startEvent.implicit);
 
@@ -351,7 +351,7 @@ final class Composer
             @safe
         {
             ensureAppendersExist(pairAppenderLevel, nodeAppenderLevel);
-            immutable startEvent = parser_.getEvent();
+            const startEvent = parser_.getEvent();
             const tag = resolver_.resolve(NodeID.Mapping, startEvent.tag, null,
                                           startEvent.implicit);
             auto pairAppender = &(pairAppenders_[pairAppenderLevel]);

--- a/source/dyaml/dumper.d
+++ b/source/dyaml/dumper.d
@@ -266,11 +266,11 @@ struct Dumper
          *
          * Throws:  YAMLException if unable to emit.
          */
-        void emit(Event[] events) @system
+        void emit(Event[] events) @safe
         {
             try
             {
-                auto emitter = Emitter(stream_, canonical_, indent_, textWidth_, lineBreak_);
+                auto emitter = new Emitter(stream_, canonical_, indent_, textWidth_, lineBreak_);
                 foreach(ref event; events)
                 {
                     emitter.emit(event);

--- a/source/dyaml/loader.d
+++ b/source/dyaml/loader.d
@@ -308,11 +308,11 @@ struct Loader
 
 
         // Parse and return all events. Used for debugging.
-        immutable(Event)[] parse() @safe
+        Event[] parse() @safe
         {
             try
             {
-                immutable(Event)[] result;
+                Event[] result;
                 while(parser_.checkEvent())
                 {
                     result ~= parser_.getEvent();

--- a/source/dyaml/parser.d
+++ b/source/dyaml/parser.d
@@ -197,7 +197,7 @@ final class Parser
          *
          * Must not be called if there are no events left.
          */
-        immutable(Event) getEvent() @trusted
+        Event getEvent() @trusted
         {
             //Get the next event and proceed further.
             if(currentEvent_.isNull && state_ !is null)
@@ -207,7 +207,7 @@ final class Parser
 
             if(!currentEvent_.isNull)
             {
-                immutable Event result = cast(immutable Event)currentEvent_;
+                Event result = currentEvent_;
                 currentEvent_.id = EventID.Invalid;
                 return result;
             }

--- a/source/dyaml/parser.d
+++ b/source/dyaml/parser.d
@@ -182,13 +182,13 @@ final class Parser
          *
          * Must not be called if there are no events left.
          */
-        immutable(Event) peekEvent() @trusted
+        Event peekEvent() @safe
         {
             if(currentEvent_.isNull && state_ !is null)
             {
                 currentEvent_ = state_();
             }
-            if(!currentEvent_.isNull){return cast(immutable Event)currentEvent_;}
+            if(!currentEvent_.isNull){return currentEvent_;}
             assert(false, "No event left to peek");
         }
 
@@ -197,7 +197,7 @@ final class Parser
          *
          * Must not be called if there are no events left.
          */
-        Event getEvent() @trusted
+        Event getEvent() @safe
         {
             //Get the next event and proceed further.
             if(currentEvent_.isNull && state_ !is null)
@@ -325,7 +325,7 @@ final class Parser
         }
 
         /// Process directives at the beginning of a document.
-        TagDirective[] processDirectives() @system
+        TagDirective[] processDirectives() @safe
         {
             // Destroy version and tag handles from previous document.
             YAMLVersion_ = null;
@@ -523,11 +523,11 @@ final class Parser
         /// Handle escape sequences in a double quoted scalar.
         ///
         /// Moved here from scanner as it can't always be done in-place with slices.
-        string handleDoubleQuotedScalarEscapes(char[] tokenValue) const @system
+        string handleDoubleQuotedScalarEscapes(char[] tokenValue) const @safe
         {
             string notInPlace;
             bool inEscape = false;
-            auto appender = appender!(char[])();
+            auto appender = appender!(string)();
             for(char[] oldValue = tokenValue; !oldValue.empty();)
             {
                 const dchar c = oldValue.front();
@@ -593,7 +593,7 @@ final class Parser
                 assert(false, "Scanner must handle unsupported escapes");
             }
 
-            return notInPlace is null ? cast(string)appender.data : notInPlace;
+            return notInPlace is null ? appender.data : notInPlace;
         }
 
         /**

--- a/source/dyaml/test/common.d
+++ b/source/dyaml/test/common.d
@@ -71,7 +71,7 @@ void run(D)(string testName, D testFunction,
     }
     else
     {
-        results ~= execute(testName, testFunction, cast(string[])[]);
+        results ~= execute(testName, testFunction, string[].init);
     }
     display(results);
 }

--- a/source/dyaml/test/constructor.d
+++ b/source/dyaml/test/constructor.d
@@ -105,10 +105,10 @@ Node[] constructCustom() @safe
 
 Node[] constructFloat() @safe
 {
-    return [Node([pair("canonical",         cast(real)685230.15),
-                  pair("exponential",       cast(real)685230.15),
-                  pair("fixed",             cast(real)685230.15),
-                  pair("sexagesimal",       cast(real)685230.15),
+    return [Node([pair("canonical",         685230.15L),
+                  pair("exponential",       685230.15L),
+                  pair("fixed",             685230.15L),
+                  pair("sexagesimal",       685230.15L),
                   pair("negative infinity", -real.infinity),
                   pair("not a number",      real.nan)])];
 }
@@ -236,8 +236,8 @@ Node[] constructValue() @safe
     return[Node([pair("link with",
                       [Node("library1.dll"), Node("library2.dll")])]),
            Node([pair("link with",
-                      [Node([pair("=", "library1.dll"), pair("version", cast(real)1.2)]),
-                       Node([pair("=", "library2.dll"), pair("version", cast(real)2.3)])])])];
+                      [Node([pair("=", "library1.dll"), pair("version", 1.2L)]),
+                       Node([pair("=", "library2.dll"), pair("version", 2.3L)])])])];
 }
 
 Node[] duplicateMergeKey() @safe
@@ -251,7 +251,7 @@ Node[] duplicateMergeKey() @safe
 
 Node[] floatRepresenterBug() @safe
 {
-    return [Node([pair(cast(real)1.0, 1L),
+    return [Node([pair(1.0L, 1L),
                   pair(real.infinity, 10L),
                   pair(-real.infinity, -10L),
                   pair(real.nan, 100L)])];
@@ -264,9 +264,9 @@ Node[] invalidSingleQuoteBug() @safe
 
 Node[] moreFloats() @safe
 {
-    return [Node([Node(cast(real)0.0),
-                  Node(cast(real)1.0),
-                  Node(cast(real)-1.0),
+    return [Node([Node(0.0L),
+                  Node(1.0L),
+                  Node(-1.0L),
                   Node(real.infinity),
                   Node(-real.infinity),
                   Node(real.nan),
@@ -275,7 +275,7 @@ Node[] moreFloats() @safe
 
 Node[] negativeFloatBug() @safe
 {
-    return [Node(cast(real)-1.0)];
+    return [Node(-1.0L)];
 }
 
 Node[] singleDotFloatBug() @safe

--- a/source/dyaml/test/emitter.d
+++ b/source/dyaml/test/emitter.d
@@ -28,7 +28,7 @@ import dyaml.token;
 ///          events2 = Second event array to compare.
 ///
 /// Returns: true if the events are equivalent, false otherwise.
-bool compareEvents(Event[] events1, Event[] events2) @system
+bool compareEvents(Event[] events1, Event[] events2) @safe
 {
     if(events1.length != events2.length){return false;}
 
@@ -78,7 +78,7 @@ bool compareEvents(Event[] events1, Event[] events2) @system
 /// Params:  dataFilename      = YAML file to parse.
 ///          canonicalFilename = Canonical YAML file used as dummy to determine
 ///                              which data files to load.
-void testEmitterOnData(string dataFilename, string canonicalFilename) @system
+void testEmitterOnData(string dataFilename, string canonicalFilename) @safe
 {
     //Must exist due to Anchor, Tags reference counts.
     auto loader = Loader.fromFile(dataFilename);
@@ -106,7 +106,7 @@ void testEmitterOnData(string dataFilename, string canonicalFilename) @system
 /// comparing events from parsing the emitted result with originally parsed events.
 ///
 /// Params:  canonicalFilename = Canonical YAML file to parse.
-void testEmitterOnCanonical(string canonicalFilename) @system
+void testEmitterOnCanonical(string canonicalFilename) @safe
 {
     //Must exist due to Anchor, Tags reference counts.
     auto loader = Loader.fromFile(canonicalFilename);
@@ -138,7 +138,7 @@ void testEmitterOnCanonical(string canonicalFilename) @system
 /// Params:  dataFilename      = YAML file to parse.
 ///          canonicalFilename = Canonical YAML file used as dummy to determine
 ///                              which data files to load.
-void testEmitterStyles(string dataFilename, string canonicalFilename) @system
+void testEmitterStyles(string dataFilename, string canonicalFilename) @safe
 {
     foreach(filename; [dataFilename, canonicalFilename])
     {
@@ -191,7 +191,7 @@ void testEmitterStyles(string dataFilename, string canonicalFilename) @system
     }
 }
 
-@system unittest
+@safe unittest
 {
     printProgress("D:YAML Emitter unittest");
     run("testEmitterOnData",      &testEmitterOnData,      ["data", "canonical"]);

--- a/source/dyaml/test/emitter.d
+++ b/source/dyaml/test/emitter.d
@@ -82,7 +82,7 @@ void testEmitterOnData(string dataFilename, string canonicalFilename) @system
 {
     //Must exist due to Anchor, Tags reference counts.
     auto loader = Loader.fromFile(dataFilename);
-    auto events = cast(Event[])loader.parse();
+    auto events = loader.parse();
     auto emitStream = new YMemoryStream;
     Dumper(emitStream).emit(events);
 
@@ -97,7 +97,7 @@ void testEmitterOnData(string dataFilename, string canonicalFilename) @system
     loader2.name        = "TEST";
     loader2.constructor = new Constructor;
     loader2.resolver    = new Resolver;
-    auto newEvents = cast(Event[])loader2.parse();
+    auto newEvents = loader2.parse();
     assert(compareEvents(events, newEvents));
 }
 
@@ -110,7 +110,7 @@ void testEmitterOnCanonical(string canonicalFilename) @system
 {
     //Must exist due to Anchor, Tags reference counts.
     auto loader = Loader.fromFile(canonicalFilename);
-    auto events = cast(Event[])loader.parse();
+    auto events = loader.parse();
     foreach(canonical; [false, true])
     {
         auto emitStream = new YMemoryStream;
@@ -126,7 +126,7 @@ void testEmitterOnCanonical(string canonicalFilename) @system
         loader2.name        = "TEST";
         loader2.constructor = new Constructor;
         loader2.resolver    = new Resolver;
-        auto newEvents = cast(Event[])loader2.parse();
+        auto newEvents = loader2.parse();
         assert(compareEvents(events, newEvents));
     }
 }
@@ -144,7 +144,7 @@ void testEmitterStyles(string dataFilename, string canonicalFilename) @system
     {
         //must exist due to Anchor, Tags reference counts
         auto loader = Loader.fromFile(canonicalFilename);
-        auto events = cast(Event[])loader.parse();
+        auto events = loader.parse();
         foreach(flowStyle; [CollectionStyle.Block, CollectionStyle.Flow])
         {
             foreach(style; [ScalarStyle.Literal, ScalarStyle.Folded,
@@ -184,7 +184,7 @@ void testEmitterStyles(string dataFilename, string canonicalFilename) @system
                 loader2.name        = "TEST";
                 loader2.constructor = new Constructor;
                 loader2.resolver    = new Resolver;
-                auto newEvents = cast(Event[])loader2.parse();
+                auto newEvents = loader2.parse();
                 assert(compareEvents(events, newEvents));
             }
         }

--- a/source/dyaml/test/emitter.d
+++ b/source/dyaml/test/emitter.d
@@ -90,7 +90,7 @@ void testEmitterOnData(string dataFilename, string canonicalFilename) @safe
     {
         writeln(dataFilename);
         writeln("ORIGINAL:\n", readText(dataFilename));
-        writeln("OUTPUT:\n", cast(string)emitStream.data);
+        writeln("OUTPUT:\n", cast(char[])emitStream.data);
     }
 
     auto loader2        = Loader.fromBuffer(emitStream.data);
@@ -120,7 +120,7 @@ void testEmitterOnCanonical(string canonicalFilename) @safe
         static if(verbose)
         {
             writeln("OUTPUT (canonical=", canonical, "):\n",
-                    cast(string)emitStream.data);
+                    cast(char[])emitStream.data);
         }
         auto loader2        = Loader.fromBuffer(emitStream.data);
         loader2.name        = "TEST";
@@ -178,7 +178,7 @@ void testEmitterStyles(string dataFilename, string canonicalFilename) @safe
                 {
                     writeln("OUTPUT (", filename, ", ", to!string(flowStyle), ", ",
                             to!string(style), ")");
-                    writeln(emitStream.data);
+                    writeln(cast(char[])emitStream.data);
                 }
                 auto loader2        = Loader.fromBuffer(emitStream.data);
                 loader2.name        = "TEST";

--- a/source/dyaml/test/inputoutput.d
+++ b/source/dyaml/test/inputoutput.d
@@ -51,7 +51,7 @@ void testUnicodeInput(string unicodeFilename) @safe
     string data     = readText(unicodeFilename);
     string expected = data.split().join(" ");
 
-    Node output = Loader.fromBuffer(cast(ubyte[])data.to!(char[])).load();
+    Node output = Loader.fromString(data).load();
     assert(output.as!string == expected);
 
     foreach(buffer; [cast(ubyte[])(bom16() ~ data.to!(wchar[])),

--- a/source/dyaml/test/reader.d
+++ b/source/dyaml/test/reader.d
@@ -21,7 +21,7 @@ void runReader(ubyte[] fileData) @safe
 {
     try
     {
-        auto reader = new Reader(cast(ubyte[])fileData);
+        auto reader = new Reader(fileData);
         while(reader.peek() != '\0') { reader.forward(); }
     }
     catch(ReaderException e)


### PR DESCRIPTION
Casting to/from immutable is undefined behaviour, especially when the data ends up being modified. No more lies.