### PR TITLE
don't throw away file/line when throwing new YAMLExceptions

### DIFF
--- a/source/dyaml/dumper.d
+++ b/source/dyaml/dumper.d
@@ -225,7 +225,7 @@ struct Dumper(Range)
             catch(YAMLException e)
             {
                 throw new YAMLException("Unable to dump YAML to stream "
-                                        ~ name_ ~ " : " ~ e.msg);
+                                        ~ name_ ~ " : " ~ e.msg, e.file, e.line);
             }
         }
 
@@ -251,7 +251,7 @@ struct Dumper(Range)
             catch(YAMLException e)
             {
                 throw new YAMLException("Unable to emit YAML to stream "
-                                        ~ name_ ~ " : " ~ e.msg);
+                                        ~ name_ ~ " : " ~ e.msg, e.file, e.line);
             }
         }
 }

--- a/source/dyaml/loader.d
+++ b/source/dyaml/loader.d
@@ -71,7 +71,7 @@ struct Loader
             catch(FileException e)
             {
                 throw new YAMLException("Unable to open file %s for YAML loading: %s"
-                                        .format(filename, e.msg));
+                                        .format(filename, e.msg), e.file, e.line);
             }
          }
          /// ditto
@@ -208,7 +208,7 @@ struct Loader
             catch(YAMLException e)
             {
                 throw new YAMLException("Unable to load YAML from %s : %s"
-                                        .format(name_, e.msg));
+                                        .format(name_, e.msg), e.file, e.line);
             }
         }
 
@@ -279,7 +279,7 @@ struct Loader
             catch(YAMLException e)
             {
                 throw new YAMLException("Unable to load YAML from %s : %s "
-                                        .format(name_, e.msg));
+                                        .format(name_, e.msg), e.file, e.line);
             }
         }
         // Scan and return all tokens. Used for debugging.
@@ -297,7 +297,7 @@ struct Loader
             catch(YAMLException e)
             {
                 throw new YAMLException("Unable to scan YAML from stream " ~
-                                        name_ ~ " : " ~ e.msg);
+                                        name_ ~ " : " ~ e.msg, e.file, e.line);
             }
         }
 
@@ -311,7 +311,7 @@ struct Loader
             catch(YAMLException e)
             {
                 throw new YAMLException("Unable to scan YAML from stream " ~
-                                        name_ ~ " : " ~ e.msg);
+                                        name_ ~ " : " ~ e.msg, e.file, e.line);
             }
         }
 


### PR DESCRIPTION
We don't need to obscure the real source of the error.