### PR TITLE
fix #205 by removing useless assertions about `Value` and `Node` sizes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ d:
  # - ldc-beta
 
 before_install:
-  - pyenv global system 3.6
+  - pyenv install 3.6.3
+  - pyenv global system 3.6.3
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja python3; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install 'meson==0.47.2'; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip3 install 'meson==0.47.2'; fi
+  - pip3 install 'meson==0.48.2'
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir .ntmp && curl -L https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip -o .ntmp/ninja-linux.zip; fi

--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -185,9 +185,6 @@ struct Node
         // Node collection style. Used to remember style this node was loaded with.
         CollectionStyle collectionStyle = CollectionStyle.invalid;
 
-        static assert(Value.sizeof <= 24, "Unexpected YAML value size");
-        static assert(Node.sizeof <= 56, "Unexpected YAML node size");
-
     public:
         /** Construct a Node from a value.
          *


### PR DESCRIPTION
Since `Value` is based on a `Variant` there's really no reason for which its size in memory would become unexpectedly huge.