### PR TITLE
make Serializer a non-templated struct

### DIFF
--- a/source/dyaml/dumper.d
+++ b/source/dyaml/dumper.d
@@ -150,13 +150,15 @@ struct Dumper
             try
             {
                 auto emitter = new Emitter!(Range, CharacterType)(range, canonical, indent_, textWidth, lineBreak);
-                auto serializer = Serializer!(Range, CharacterType)(emitter, resolver, explicitStart ? Yes.explicitStart : No.explicitStart,
+                auto serializer = Serializer(resolver, explicitStart ? Yes.explicitStart : No.explicitStart,
                                              explicitEnd ? Yes.explicitEnd : No.explicitEnd, YAMLVersion, tags_);
+                serializer.startStream(emitter);
                 foreach(ref document; documents)
                 {
                     auto data = representData(document, defaultScalarStyle, defaultCollectionStyle);
-                    serializer.serialize(data);
+                    serializer.serialize(emitter, data);
                 }
+                serializer.endStream(emitter);
             }
             catch(YAMLException e)
             {


### PR DESCRIPTION
This also makes the start/end-of-stream writing explicit. Using a destructor to write the end meant that an end could be written even after an error occurred, which isn't helpful.