### PR TITLE
remove pointless Composer destructor

### DIFF
--- a/source/dyaml/composer.d
+++ b/source/dyaml/composer.d
@@ -75,14 +75,6 @@ struct Composer
             resolver_ = resolver;
         }
 
-        ///Destroy the composer.
-        pure @safe nothrow ~this()
-        {
-            parser_ = null;
-            anchors_.destroy();
-            anchors_ = null;
-        }
-
         /**
          * Determine if there are any nodes left.
          *


### PR DESCRIPTION
The order in which destructors are called is undefined, so it's possible that we're wasting time destroying already-destroyed things here. It's also not necessary, so let's just remove it.