### PR TITLE
Some Exception-related fixes

### DIFF
--- a/source/dyaml/constructor.d
+++ b/source/dyaml/constructor.d
@@ -38,7 +38,7 @@ class ConstructorException : YAMLException
     /// Params:  msg   = Error message.
     ///          start = Start position of the error context.
     ///          end   = End position of the error context.
-    this(string msg, Mark start, Mark end, string file = __FILE__, int line = __LINE__)
+    this(string msg, Mark start, Mark end, string file = __FILE__, size_t line = __LINE__)
         @safe pure nothrow
     {
         super(msg ~ "\nstart: " ~ start.toString() ~ "\nend: " ~ end.toString(),

--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -33,7 +33,7 @@ class NodeException : YAMLException
         //
         // Params:  msg   = Error message.
         //          start = Start position of the node.
-        this(string msg, Mark start, string file = __FILE__, int line = __LINE__)
+        this(string msg, Mark start, string file = __FILE__, size_t line = __LINE__)
             @safe
         {
             super(msg ~ "\nNode at: " ~ start.toString(), file, line);

--- a/source/dyaml/reader.d
+++ b/source/dyaml/reader.d
@@ -34,7 +34,7 @@ package:
 ///Exception thrown at Reader errors.
 class ReaderException : YAMLException
 {
-    this(string msg, string file = __FILE__, int line = __LINE__)
+    this(string msg, string file = __FILE__, size_t line = __LINE__)
         @safe pure nothrow
     {
         super("Reader error: " ~ msg, file, line);


### PR DESCRIPTION
Just some cleanup related to exception handling.

- some Exceptions used int for line numbers instead of size_t
- most of Scanner isn't nothrow/nogc so avoiding throwing Exceptions directly wasn't saving us anything