### PR TITLE
change accidental octal literals into decimal literals

### DIFF
--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -254,7 +254,7 @@ struct Node
             }
             // Time
             {
-                auto node = Node(SysTime(DateTime(2005, 06, 15, 20, 00, 00), UTC()));
+                auto node = Node(SysTime(DateTime(2005, 6, 15, 20, 0, 0), UTC()));
             }
             // Integer, dumped as a string
             {

--- a/source/dyaml/representer.d
+++ b/source/dyaml/representer.d
@@ -152,7 +152,7 @@ Node representData(const Node data, ScalarStyle defaultScalarStyle, CollectionSt
 
 @safe unittest
 {
-    assert(representData(Node(SysTime(DateTime(2000, 03, 14, 12, 34, 56), UTC())), ScalarStyle.invalid, CollectionStyle.invalid) == Node("2000-03-14T12:34:56Z", "tag:yaml.org,2002:timestamp"));
+    assert(representData(Node(SysTime(DateTime(2000, 3, 14, 12, 34, 56), UTC())), ScalarStyle.invalid, CollectionStyle.invalid) == Node("2000-03-14T12:34:56Z", "tag:yaml.org,2002:timestamp"));
 }
 
 @safe unittest


### PR DESCRIPTION
By spec, these aren't allowed, but the D compiler currently accepts them. Let's fix this now in case this starts being rejected later.