### PR TITLE
Remove 'in' storage class from nextState delegate

### DIFF
--- a/source/dyaml/parser.d
+++ b/source/dyaml/parser.d
@@ -825,7 +825,7 @@ final class Parser
         }
 
         ///Parse a key in flow context.
-        Event parseFlowKey(in Event delegate() @safe nextState) @safe
+        Event parseFlowKey(Event delegate() @safe nextState) @safe
         {
             const token = scanner_.front;
             scanner_.popFront();
@@ -848,7 +848,7 @@ final class Parser
         }
 
         ///Parse a mapping value in a flow context.
-        Event parseFlowValue(TokenID checkId, in Event delegate() @safe nextState)
+        Event parseFlowValue(TokenID checkId, Event delegate() @safe nextState)
             @safe
         {
             if(scanner_.front.id == TokenID.value)


### PR DESCRIPTION
```
The 'in' storage class on delegate should make it 'const scope',
but those delegates are stored within the function so cannot be 'scope'.
```

Found while trying to compile with `-preview=in`.