### PR TITLE
Add `Node.startMark`

### DIFF
--- a/source/dyaml/exception.d
+++ b/source/dyaml/exception.d
@@ -25,8 +25,7 @@ class YAMLException : Exception
     }
 }
 
-package:
-// Position in a YAML stream, used for error messages.
+/// Position in a YAML stream, used for error messages.
 struct Mark
 {
     package:
@@ -45,6 +44,18 @@ struct Mark
             column_ = cast(ushort)column;
         }
 
+        /// Get a line number.
+        @property ushort line() @safe pure nothrow @nogc const
+        {
+            return line_;
+        }
+
+        /// Get a column number.
+        @property ushort column() @safe pure nothrow @nogc const
+        {
+            return column_;
+        }
+
         /// Get a string representation of the mark.
         string toString() @safe pure nothrow const
         {
@@ -57,6 +68,7 @@ struct Mark
         }
 }
 
+package:
 // A struct storing parameters to the MarkedYAMLException constructor.
 struct MarkedYAMLExceptionData
 {

--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -402,6 +402,12 @@ struct Node
             return tag_;
         }
 
+        /// Return the start position of the node.
+        @property Mark startMark()  const @safe pure nothrow
+        {
+            return startMark_;
+        }
+
         /** Equality test.
          *
          * If T is Node, recursively compares all subnodes.


### PR DESCRIPTION
This request is to solve #256 by making `dyaml.exception.Mark` public and by adding `dyaml.node.Node.startMark` to get the start position of the node.

Although it lacks some information such as the file name, it is quite useful to provide fine-grained messages.
