### PR TITLE
Move initializer of `dyaml.resolver.regexes` from static this

### DIFF
--- a/source/dyaml/resolver.d
+++ b/source/dyaml/resolver.d
@@ -27,50 +27,43 @@ import dyaml.exception;
 /// Type of `regexes`
 private alias RegexType = Tuple!(string, "tag", const Regex!char, "regexp", string, "chars");
 
-private immutable RegexType[] regexes;
-
-shared static this() @safe
-{
-    RegexType[] tmp;
-    tmp ~= RegexType("tag:yaml.org,2002:bool",
-                     regex(r"^(?:yes|Yes|YES|no|No|NO|true|True|TRUE" ~
-                           "|false|False|FALSE|on|On|ON|off|Off|OFF)$"),
-                     "yYnNtTfFoO");
-    tmp ~= RegexType("tag:yaml.org,2002:float",
-                     regex(r"^(?:[-+]?([0-9][0-9_]*)\\.[0-9_]*" ~
-                           "(?:[eE][-+][0-9]+)?|[-+]?(?:[0-9][0-9_]" ~
-                           "*)?\\.[0-9_]+(?:[eE][-+][0-9]+)?|[-+]?" ~
-                           "[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]" ~
-                           "*|[-+]?\\.(?:inf|Inf|INF)|\\." ~
-                           "(?:nan|NaN|NAN))$"),
-                     "-+0123456789.");
-    tmp ~= RegexType("tag:yaml.org,2002:int",
-                     regex(r"^(?:[-+]?0b[0-1_]+" ~
-                           "|[-+]?0[0-7_]+" ~
-                           "|[-+]?(?:0|[1-9][0-9_]*)" ~
-                           "|[-+]?0x[0-9a-fA-F_]+" ~
-                           "|[-+]?[1-9][0-9_]*(?::[0-5]?[0-9])+)$"),
-                     "-+0123456789");
-    tmp ~= RegexType("tag:yaml.org,2002:merge", regex(r"^<<$"), "<");
-    tmp ~= RegexType("tag:yaml.org,2002:null",
-                     regex(r"^$|^(?:~|null|Null|NULL)$"), "~nN\0");
-    tmp ~= RegexType("tag:yaml.org,2002:timestamp",
-                     regex(r"^[0-9][0-9][0-9][0-9]-[0-9][0-9]-" ~
-                           "[0-9][0-9]|[0-9][0-9][0-9][0-9]-[0-9]" ~
-                           "[0-9]?-[0-9][0-9]?[Tt]|[ \t]+[0-9]" ~
-                           "[0-9]?:[0-9][0-9]:[0-9][0-9]" ~
-                           "(?:\\.[0-9]*)?(?:[ \t]*Z|[-+][0-9]" ~
-                           "[0-9]?(?::[0-9][0-9])?)?$"),
-                     "0123456789");
-    tmp ~= RegexType("tag:yaml.org,2002:value", regex(r"^=$"), "=");
-
+private immutable RegexType[] regexes = [
+    RegexType("tag:yaml.org,2002:bool",
+              regex(r"^(?:yes|Yes|YES|no|No|NO|true|True|TRUE" ~
+                     "|false|False|FALSE|on|On|ON|off|Off|OFF)$"),
+              "yYnNtTfFoO"),
+    RegexType("tag:yaml.org,2002:float",
+              regex(r"^(?:[-+]?([0-9][0-9_]*)\\.[0-9_]*" ~
+                     "(?:[eE][-+][0-9]+)?|[-+]?(?:[0-9][0-9_]" ~
+                     "*)?\\.[0-9_]+(?:[eE][-+][0-9]+)?|[-+]?" ~
+                     "[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]" ~
+                     "*|[-+]?\\.(?:inf|Inf|INF)|\\." ~
+                     "(?:nan|NaN|NAN))$"),
+              "-+0123456789."),
+    RegexType("tag:yaml.org,2002:int",
+              regex(r"^(?:[-+]?0b[0-1_]+" ~
+                     "|[-+]?0[0-7_]+" ~
+                     "|[-+]?(?:0|[1-9][0-9_]*)" ~
+                     "|[-+]?0x[0-9a-fA-F_]+" ~
+                     "|[-+]?[1-9][0-9_]*(?::[0-5]?[0-9])+)$"),
+              "-+0123456789"),
+    RegexType("tag:yaml.org,2002:merge", regex(r"^<<$"), "<"),
+    RegexType("tag:yaml.org,2002:null",
+              regex(r"^$|^(?:~|null|Null|NULL)$"), "~nN\0"),
+    RegexType("tag:yaml.org,2002:timestamp",
+              regex(r"^[0-9][0-9][0-9][0-9]-[0-9][0-9]-" ~
+                     "[0-9][0-9]|[0-9][0-9][0-9][0-9]-[0-9]" ~
+                     "[0-9]?-[0-9][0-9]?[Tt]|[ \t]+[0-9]" ~
+                     "[0-9]?:[0-9][0-9]:[0-9][0-9]" ~
+                     "(?:\\.[0-9]*)?(?:[ \t]*Z|[-+][0-9]" ~
+                     "[0-9]?(?::[0-9][0-9])?)?$"),
+              "0123456789"),
+    RegexType("tag:yaml.org,2002:value", regex(r"^=$"), "="),
 
     //The following resolver is only for documentation purposes. It cannot work
     //because plain scalars cannot start with '!', '&', or '*'.
-    tmp ~= RegexType("tag:yaml.org,2002:yaml", regex(r"^(?:!|&|\*)$"), "!&*");
-
-    regexes = () @trusted { return cast(immutable)tmp; }();
-}
+    RegexType("tag:yaml.org,2002:yaml", regex(r"^(?:!|&|\*)$"), "!&*"),
+];
 
 /**
  * Resolves YAML tags (data types).


### PR DESCRIPTION
It moves the initialization step for `regexes` from static this to a simple initializer.
It partially solves #33.
