### PR TITLE
rework with mir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,14 @@ example.yaml
 
 # Unittest Coverage output #
 *.lst
+dyaml-test-library
+examples/mir-serde/mir_serde
+examples/representer/representer-test-application
+examples/resolver/resolver-test-application
+examples/tojson/tojson
+examples/tojson/tojson-test-application
+examples/yaml_bench/benchmark
+examples/yaml_bench/benchmark-test-application
+examples/yaml_gen/yaml_gen-test-application
+examples/yaml_stats/yaml_stats-test-application
+examples/constructor/constructor-test-application

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,16 @@ script:
   - meson build && ninja -j8 -C build
   - ninja -j8 -C build test -v
   - dub build
-  - "dub build dyaml:benchmark"
-  - "dub build dyaml:constructor"
-  - "dub build dyaml:getting-started"
-  - "dub build dyaml:representer"
-  - "dub build dyaml:resolver"
-  - "dub build dyaml:testsuite"
-  - "dub build dyaml:tojson"
-  - "dub build dyaml:yaml_gen"
-  - "dub build dyaml:yaml_stats"
+  - dub build dyaml:benchmark
+  - dub build dyaml:constructor
+  - dub build dyaml:getting-started
+  - dub build dyaml:representer
+  - dub build dyaml:resolver
+  - dub build dyaml:testsuite
+  - dub build dyaml:tojson
+  - dub build dyaml:yaml_gen
+  - dub build dyaml:yaml_stats
   - dub test --build=unittest-cov
+  - dub --root examples/mir-serde
 after_success:
  - bash <(curl -s https://codecov.io/bash)

--- a/contrib/mir-algorithm.wrap
+++ b/contrib/mir-algorithm.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory=mir-algorithm
+url=https://github.com/libmir/mir-algorithm.git
+revision=head

--- a/contrib/mir-core.wrap
+++ b/contrib/mir-core.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory=mir-core
+url=https://github.com/libmir/mir-core.git
+revision=head

--- a/docs/tutorials/yaml_syntax.md
+++ b/docs/tutorials/yaml_syntax.md
@@ -230,12 +230,12 @@ Some of these might change in the future (especially !!map and !!set).
 
 |YAML tag               |D type                 |
 |-----------------------|-----------------------|
-|!!null                 |dyaml.node.YAMLNull    |
+|!!null                 |typeof(null)           |
 |!!bool                 |bool                   |
 |!!int                  |long                   |
-|!!float                |real                   |
+|!!float                |double                 |
 |!!binary               |ubyte[]                |
-|!!timestamp            |std.datetime.SysTime   |
+|!!timestamp            |mir.timestamp.Timestamp|
 |!!map, !!omap, !!pairs |dyaml.node.Node.Pair[] |
 |!!seq, !!set           |dyaml.node.Node[]      |
 |!!str                  |string                 |

--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,8 @@
     ],
     "license": "BSL-1.0",
     "dependencies": {
-        "tinyendian" :  "~>0.2.0"
+        "tinyendian" :  "~>0.2.0",
+        "mir-algorithm" : ">=3.10.71"
     },
     "homepage": "https://github.com/dlang-community/D-YAML",
     "copyright": "Copyright © 2011-2018, Ferdinand Majerech",

--- a/examples/constructor/dub.json
+++ b/examples/constructor/dub.json
@@ -5,6 +5,6 @@
     "mainSourceFile": "main.d",
     "dependencies":
     {
-        "dyaml": { "version" : "*"}
+        "dyaml": { "path" : "../../"}
     }
 }

--- a/examples/getting_started/dub.json
+++ b/examples/getting_started/dub.json
@@ -5,6 +5,6 @@
     "mainSourceFile": "main.d",
     "dependencies":
     {
-        "dyaml": { "version" : "*" }
+        "dyaml": { "path" : "../../"}
     }
 }

--- a/examples/mir-serde/dub.sdl
+++ b/examples/mir-serde/dub.sdl
@@ -1,0 +1,3 @@
+name "mir_serde"
+dependency "mir-ion" version="*"
+dependency "dyaml" path="../../"

--- a/examples/mir-serde/source/main.d
+++ b/examples/mir-serde/source/main.d
@@ -1,0 +1,69 @@
+import dyaml;
+
+import mir.algebraic_alias.json;
+import mir.format;
+import mir.ion.conv: json2ion;
+import mir.ion.deser.ion: deserializeIon;
+import mir.ion.ser.ion: serializeIon;
+import mir.ion.ser.json: serializeJsonPretty;
+import mir.serde;
+
+static immutable yaml = `
+    type: request
+    value: 123.4
+    name: "London"
+`;
+
+struct S
+{
+    enum Type {
+        response,
+        request,
+    }
+
+    private this(Type type, string name, JsonAlgebraic value) {
+        this.type = type;
+        this._name = name;
+        this.value = value;
+    }
+
+    Type type;
+
+    private string _name;
+
+    @serdeKeys("name")
+    void setName(string name) @property
+    {
+        _name = name;
+    }
+
+    @serdeKeys("name")
+    auto getName() @property
+    {
+        return _name;
+    }
+
+    JsonAlgebraic value;
+}
+
+static immutable json = "{
+\t\"type\": \"request\",
+\t\"value\": 123.4,
+\t\"name\": \"London\"
+}";
+
+import std.stdio;
+
+void main()
+{
+    assert(Loader.fromString(yaml).load().serializeJsonPretty == json);
+    auto s = Loader.fromString(yaml).load().serializeIon.deserializeIon!S;
+    assert(s == S(S.Type.request, "London", JsonAlgebraic(123.4)));
+
+    auto app = stringBuf();
+    Dumper().dump(&app, json.json2ion.deserializeIon!Node);
+    auto yamlData = app.data.idup;
+    import std.stdio;
+    writeln(s);
+    writeln(yamlData);
+}

--- a/examples/representer/dub.json
+++ b/examples/representer/dub.json
@@ -5,6 +5,6 @@
     "mainSourceFile": "main.d",
     "dependencies":
     {
-        "dyaml": { "version" : "*" }
+        "dyaml": { "path" : "../../"}
     }
 }

--- a/examples/resolver/dub.json
+++ b/examples/resolver/dub.json
@@ -5,6 +5,6 @@
     "mainSourceFile": "main.d",
     "dependencies":
     {
-        "dyaml": { "version" : "*" }
+        "dyaml": { "path" : "../../"}
     }
 }

--- a/examples/tojson/dub.json
+++ b/examples/tojson/dub.json
@@ -3,6 +3,6 @@
     "targetType": "executable",
     "dependencies":
     {
-        "dyaml": "*"
+        "dyaml": { "path" : "../../"}
     }
 }

--- a/examples/tojson/source/app.d
+++ b/examples/tojson/source/app.d
@@ -1,5 +1,6 @@
 module dyaml.tojson;
-import std.datetime;
+
+import mir.timestamp;
 import std.json;
 import std.stdio;
 import dyaml;
@@ -37,18 +38,17 @@ JSONValue toJSON(Node node)
             output = node.as!long;
             break;
         case NodeType.decimal:
-            output = node.as!real;
+            output = node.as!double;
             break;
         case NodeType.boolean:
             output = node.as!bool;
             break;
         case NodeType.timestamp:
-            output = node.as!SysTime.toISOExtString();
+            output = node.as!Timestamp.toISOExtString;
             break;
         case NodeType.merge:
         case NodeType.null_:
         case NodeType.binary:
-        case NodeType.invalid:
     }
     return output;
 }

--- a/examples/yaml_bench/dub.json
+++ b/examples/yaml_bench/dub.json
@@ -5,6 +5,6 @@
     "mainSourceFile": "yaml_bench.d",
     "dependencies":
     {
-        "dyaml": { "version" : "*" }
+        "dyaml": { "path" : "../../"}
     }
 }

--- a/examples/yaml_bench/yaml_bench.d
+++ b/examples/yaml_bench/yaml_bench.d
@@ -2,9 +2,9 @@
 module dyaml.yaml_bench;
 //Benchmark that loads, and optionally extracts data from and/or emits a YAML file.
 
+import mir.timestamp;
 import std.algorithm;
 import std.conv;
-import std.datetime.systime;
 import std.datetime.stopwatch;
 import std.file;
 import std.getopt;
@@ -23,12 +23,12 @@ void extract(ref Node document) @safe
             case NodeID.scalar:
                  switch(root.tag)
                 {
-                    case "tag:yaml.org,2002:null":      auto value = root.as!YAMLNull;  break;
+                    case "tag:yaml.org,2002:null":      auto value = root.as!(typeof(null));  break;
                     case "tag:yaml.org,2002:bool":      auto value = root.as!bool;      break;
                     case "tag:yaml.org,2002:int":       auto value = root.as!long;      break;
-                    case "tag:yaml.org,2002:float":     auto value = root.as!real;      break;
+                    case "tag:yaml.org,2002:float":     auto value = root.as!double;    break;
                     case "tag:yaml.org,2002:binary":    auto value = root.as!(ubyte[]); break;
-                    case "tag:yaml.org,2002:timestamp": auto value = root.as!SysTime;   break;
+                    case "tag:yaml.org,2002:timestamp": auto value = root.as!Timestamp; break;
                     case "tag:yaml.org,2002:str":       auto value = root.as!string;    break;
                     default: writeln("Unrecognozed tag: ", root.tag);
                 }

--- a/examples/yaml_gen/dub.json
+++ b/examples/yaml_gen/dub.json
@@ -5,6 +5,6 @@
     "mainSourceFile": "yaml_gen.d",
     "dependencies":
     {
-        "dyaml": { "version" : "*" }
+        "dyaml": { "path" : "../../"}
     }
 }

--- a/examples/yaml_gen/yaml_gen.d
+++ b/examples/yaml_gen/yaml_gen.d
@@ -34,7 +34,7 @@ static this()
     generators["set"]       = &genSet;
 }
 
-real randomNormalized(const string distribution = "linear")
+double randomNormalized(const string distribution = "linear")
 {
     auto generator = Random(unpredictableSeed());
     const r = uniform!"[]"(0.0L, 1.0L, generator);
@@ -58,7 +58,7 @@ long randomLong(const long min, const long max, const string distribution = "lin
     return min + cast(long)round((max - min) * randomNormalized(distribution));
 }
 
-real randomReal(const real min, const real max, const string distribution = "linear")
+double randomReal(const double min, const double max, const string distribution = "linear")
 {
     return min + (max - min) * randomNormalized(distribution);
 }
@@ -111,7 +111,7 @@ Node genFloat(bool root = false)
 {
     auto range = config["float"]["range"];
 
-    const result = randomReal(range["min"].as!real, range["max"].as!real,
+    const result = randomReal(range["min"].as!double, range["max"].as!double,
                               range["dist"].as!string);
 
     return Node(result);
@@ -129,7 +129,7 @@ Node genTimestamp(bool root = false)
     auto hnsecs = randomLong(range["min"].as!ulong, range["max"].as!ulong,
                              range["dist"].as!string);
 
-    if(randomNormalized() <= config["timestamp"]["round-chance"].as!real)
+    if(randomNormalized() <= config["timestamp"]["round-chance"].as!double)
     {
         hnsecs -= hnsecs % 10000000;
     }

--- a/examples/yaml_stats/dub.json
+++ b/examples/yaml_stats/dub.json
@@ -5,6 +5,6 @@
     "mainSourceFile": "yaml_stats.d",
     "dependencies":
     {
-        "dyaml": { "version" : "*" }
+        "dyaml": { "path" : "../../"}
     }
 }

--- a/examples/yaml_stats/yaml_stats.d
+++ b/examples/yaml_stats/yaml_stats.d
@@ -66,8 +66,8 @@ string statistics(ref Node document)
                     "\nAverage mapping length:  %s" ~
                   "\n\n%s",
                   nodes, scalars, sequences, mappings,
-                  sequences == 0.0 ? 0.0 : cast(real)seqItems / sequences,
-                  mappings  == 0.0 ? 0.0 : cast(real)mapPairs / mappings,
+                  sequences == 0.0 ? 0.0 : cast(double)seqItems / sequences,
+                  mappings  == 0.0 ? 0.0 : cast(double)mapPairs / mappings,
                   tagStats);
 }
 

--- a/meson.build
+++ b/meson.build
@@ -45,12 +45,20 @@ dyaml_src = [
 ]
 install_subdir('source/dyaml', install_dir: 'include/d/yaml/')
 
-tinyendian_dep = dependency('tinyendian', version: '>=0.2.0', fallback: ['tinyendian', 'tinyendian_dep'])
+subprojects = ['mir-core', 'mir-algorithm']
+
+required_deps = []
+
+foreach p : subprojects 
+    required_deps += dependency(p, fallback : [p, 'this_dep'])
+endforeach
+
+required_deps += dependency('tinyendian', version: '>=0.2.0', fallback: ['tinyendian', 'tinyendian_dep'])
 
 dyaml_lib = library('dyaml',
         [dyaml_src],
         include_directories: [src_dir],
-        dependencies: [tinyendian_dep],
+        dependencies: required_deps,
         install: true,
         version: meson.project_version(),
         soversion: project_soversion
@@ -66,5 +74,7 @@ pkgc.generate(name: 'dyaml',
 dyaml_dep = declare_dependency(
     link_with: dyaml_lib,
     include_directories: [src_dir],
-    dependencies: [tinyendian_dep]
+    dependencies: required_deps
 )
+
+this_dep = dyaml_dep

--- a/output.yaml
+++ b/output.yaml
@@ -1,0 +1,2 @@
+%YAML 1.1
+--- [!color 'FF0000', !color '00FF00', !color '0000FF']

--- a/source/dyaml/loader.d
+++ b/source/dyaml/loader.d
@@ -390,5 +390,5 @@ struct Loader
 {
     auto yaml = "{\n\"root\": {\n\t\"key\": \"value\"\n    }\n}";
     auto doc = Loader.fromString(yaml).load();
-    assert(doc.isValid);
+    assert(doc._is!(Node.Pair[]));
 }

--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -8,19 +8,15 @@
 /// and to prepare data to emit.
 module dyaml.node;
 
-
+import mir.timestamp;
 import std.algorithm;
 import std.array;
 import std.conv;
-import std.datetime;
 import std.exception;
-import std.math;
 import std.meta : AliasSeq;
 import std.range;
 import std.string;
 import std.traits;
-import std.typecons;
-import std.variant;
 
 import dyaml.event;
 import dyaml.exception;
@@ -51,11 +47,7 @@ enum NodeID : ubyte
 }
 
 /// Null YAML type. Used in nodes with _null values.
-struct YAMLNull
-{
-    /// Used for string conversion.
-    string toString() const pure @safe nothrow {return "null";}
-}
+alias YAMLNull = typeof(null);
 
 // Merge YAML type, used to support "tag:yaml.org,2002:merge".
 package struct YAMLMerge{}
@@ -93,20 +85,7 @@ private struct Pair
         }
 }
 
-enum NodeType
-{
-    null_,
-    merge,
-    boolean,
-    integer,
-    decimal,
-    binary,
-    timestamp,
-    string,
-    mapping,
-    sequence,
-    invalid
-}
+alias NodeType = Node.Value.Kind;
 
 /** YAML node.
  *
@@ -116,20 +95,57 @@ enum NodeType
  */
 struct Node
 {
+    import std.meta: staticIndexOf;
+    import mir.algebraic: TaggedVariant, visit, tryVisit, optionalVisit;
     public:
         alias Pair = .Pair;
 
+
+
+
+
+
+
+
+
+
+
+
     package:
         // YAML value type.
-        alias Value = Algebraic!(YAMLNull, YAMLMerge, bool, long, real, ubyte[], SysTime, string,
-                         Node.Pair[], Node[]);
+        alias Value = TaggedVariant!(
+            [
+                "null_",
+                "merge",
+                "boolean",
+                "integer",
+                "decimal",
+                "binary",
+                "timestamp",
+                "string",
+                "mapping",
+                "sequence",
+            ],
+            typeof(null),
+            YAMLMerge,
+            bool,
+            long,
+            double,
+            ubyte[],
+            Timestamp,
+            string,
+            Node.Pair[],
+            Node[],
+        );
 
         // Can Value hold this type naturally?
         enum allowed(T) = isIntegral!T ||
                        isFloatingPoint!T ||
                        isSomeString!T ||
                        is(Unqual!T == bool) ||
-                       Value.allowed!T;
+                       staticIndexOf!(T, Value.AllowedTypes) >= 0 ||
+                       __traits(compiles, Timestamp(T.init)) ||
+                       is(T == Value);
 
         // Stored value.
         Value value_;
@@ -194,7 +210,7 @@ struct Node
             }
             else static if(isFloatingPoint!T)
             {
-                setValue(cast(real)value);
+                setValue(cast(double)value);
             }
             else static if (isArray!T)
             {
@@ -255,7 +271,7 @@ struct Node
             }
             // Time
             {
-                auto node = Node(SysTime(DateTime(2005, 6, 15, 20, 0, 0), UTC()));
+                auto node = Node(Timestamp(2005, 6, 15, 20, 0, 0));
             }
             // Integer, dumped as a string
             {
@@ -390,12 +406,6 @@ struct Node
 
         }
 
-        /// Is this node valid (initialized)?
-        @property bool isValid()    const @safe pure nothrow
-        {
-            return value_.hasValue;
-        }
-
         /// Return tag of the node.
         @property string tag()      const @safe nothrow
         {
@@ -434,7 +444,7 @@ struct Node
                 // NaNs aren't normally equal to each other, but we'll pretend they are.
                 static if(isFloatingPoint!T)
                 {
-                    return rhs == stored || (isNaN(rhs) && isNaN(stored));
+                    return rhs == stored || (rhs != rhs && stored != stored);
                 }
                 else
                 {
@@ -455,8 +465,8 @@ struct Node
             assert(node != "42");
             assert(node != "43");
 
-            auto node2 = Node(YAMLNull());
-            assert(node2 == YAMLNull());
+            auto node2 = Node(null);
+            assert(node2 == null);
 
             const node3 = Node(42);
             assert(node3 == 42);
@@ -475,7 +485,7 @@ struct Node
          * Numeric values are range checked, throwing if out of range of
          * requested type.
          *
-         * Timestamps are stored as std.datetime.SysTime.
+         * Timestamps are stored as mir.timestamp.Timestamp.
          * Binary values are decoded and stored as ubyte[].
          *
          * To get a null value, use get!YAMLNull . This is to
@@ -500,8 +510,6 @@ struct Node
         inout(T) get(T, Flag!"stringConversion" stringConversion = Yes.stringConversion)() inout
             if (allowed!(Unqual!T) || hasNodeConstructor!(inout(Unqual!T)) || (!hasIndirections!(Unqual!T) && hasNodeConstructor!(Unqual!T)))
         {
-            if(isType!(Unqual!T)){return getValue!T;}
-
             static if(!allowed!(Unqual!T))
             {
                 static if (hasSimpleNodeConstructor!(Unqual!T) || hasSimpleNodeConstructor!(inout(Unqual!T)))
@@ -529,10 +537,23 @@ struct Node
                 {
                     static assert(0, "Unhandled user type");
                 }
-            } else {
+            }
+            else
+            static if (is(typeof(Timestamp.init.opCast!(Unqual!T))))
+            {
+                return value_.trustedGet!Timestamp.opCast!(Unqual!T);
+            }
+            else
+            {
 
                 // If we're getting from a mapping and we're not getting Node.Pair[],
                 // we're getting the default value.
+                static if (staticIndexOf!(Unqual!T, Value.AllowedTypes) >= 0)
+                {
+                    if (_is!(Unqual!T))
+                        return value_.trustedGet!(Unqual!T);
+                }
+
                 if(nodeID == NodeID.mapping){return this["="].get!( T, stringConversion);}
 
                 static if(isSomeString!T)
@@ -551,7 +572,7 @@ struct Node
                         {
                             return coerceValue!T();
                         }
-                        catch(VariantException e)
+                        catch(Exception e)
                         {
                             throw new NodeException("Unable to convert node value to string", startMark_);
                         }
@@ -564,13 +585,12 @@ struct Node
                         case NodeType.integer:
                             return to!T(getValue!long);
                         case NodeType.decimal:
-                            return to!T(getValue!real);
+                            return to!T(getValue!double);
                         case NodeType.binary:
                         case NodeType.string:
                         case NodeType.boolean:
                         case NodeType.null_:
                         case NodeType.merge:
-                        case NodeType.invalid:
                         case NodeType.timestamp:
                         case NodeType.mapping:
                         case NodeType.sequence:
@@ -849,7 +869,7 @@ struct Node
             assertThrown!NodeException(Node("42").get!int);
             assertThrown!NodeException(Node("42").get!double);
             assertThrown!NodeException(Node(long.max).get!ushort);
-            Node(YAMLNull()).get!YAMLNull;
+            Node(null).get!YAMLNull;
         }
         @safe unittest
         {
@@ -971,10 +991,10 @@ struct Node
             assert(nmap["14"].as!int == 14);
             assert(null !is collectException(nmap["42"]));
 
-            narray.add(YAMLNull());
-            nmap.add(YAMLNull(), "Nothing");
-            assert(narray[4].as!YAMLNull == YAMLNull());
-            assert(nmap[YAMLNull()].as!string == "Nothing");
+            narray.add(null);
+            nmap.add(null, "Nothing");
+            assert(narray[4].as!YAMLNull == null);
+            assert(nmap[null].as!string == "Nothing");
 
             assertThrown!NodeException(nmap[11]);
             assertThrown!NodeException(nmap[14]);
@@ -1044,16 +1064,16 @@ struct Node
             assert(!map.containsKey(1));
             assert(!map.containsKey("5"));
 
-            assert(!seq.contains(YAMLNull()));
-            assert(!map.contains(YAMLNull()));
-            assert(!map.containsKey(YAMLNull()));
-            seq.add(YAMLNull());
-            map.add("Nothing", YAMLNull());
-            assert(seq.contains(YAMLNull()));
-            assert(map.contains(YAMLNull()));
-            assert(!map.containsKey(YAMLNull()));
-            map.add(YAMLNull(), "Nothing");
-            assert(map.containsKey(YAMLNull()));
+            assert(!seq.contains(null));
+            assert(!map.contains(null));
+            assert(!map.containsKey(null));
+            seq.add(null);
+            map.add("Nothing", null);
+            assert(seq.contains(null));
+            assert(map.contains(null));
+            assert(!map.containsKey(null));
+            map.add(null, "Nothing");
+            assert(map.containsKey(null));
 
             auto map2 = Node([1, 2, 3, 4], [1, 2, 3, 4]);
             assert(!map2.contains("1"));
@@ -1151,8 +1171,8 @@ struct Node
                 assert(length == 5);
                 assert(opIndex(3).as!int == 42);
 
-                opIndexAssign(YAMLNull(), 0);
-                assert(opIndex(0) == YAMLNull());
+                opIndexAssign(null, 0);
+                assert(opIndex(0) == null);
             }
             with(Node(["1", "2", "3"], [4, 5, 6]))
             {
@@ -1168,8 +1188,8 @@ struct Node
                 assert(opIndex("3").as!int == 42);
                 assert(opIndex(3).as!int == 43);
 
-                opIndexAssign(YAMLNull(), "2");
-                assert(opIndex("2") == YAMLNull());
+                opIndexAssign(null, "2");
+                assert(opIndex("2") == null);
             }
         }
 
@@ -1662,7 +1682,7 @@ struct Node
 
             Node nmap2 = Node([Pair(k1, Node(cast(long)5)),
                                Pair(k2, Node(true)),
-                               Pair(k3, Node(cast(real)1.0)),
+                               Pair(k3, Node(cast(double)1.0)),
                                Pair(k4, Node("yarly"))]);
 
             foreach(string key, Node value; nmap2)
@@ -1733,7 +1753,7 @@ struct Node
          */
         void add(T)(T value)
         {
-            if (!isValid)
+            if (value_.isNull)
             {
                 setValue(Node[].init);
             }
@@ -1784,7 +1804,7 @@ struct Node
          */
         void add(K, V)(K key, V value)
         {
-            if (!isValid)
+            if (value_.isNull)
             {
                 setValue(Node.Pair[].init);
             }
@@ -1895,18 +1915,18 @@ struct Node
                 assert(opIndex(2).as!int == 4);
                 assert(opIndex(3).as!int == 3);
 
-                add(YAMLNull());
+                add(null);
                 assert(length == 5);
-                remove(YAMLNull());
+                remove(null);
                 assert(length == 4);
             }
             with(Node(["1", "2", "3"], [4, 5, 6]))
             {
                 remove(4);
                 assert(length == 2);
-                add("nullkey", YAMLNull());
+                add("nullkey", null);
                 assert(length == 3);
-                remove(YAMLNull());
+                remove(null);
                 assert(length == 2);
             }
         }
@@ -1949,9 +1969,9 @@ struct Node
                 assert(length == 3);
                 removeAt("2");
                 assert(length == 2);
-                add(YAMLNull(), "nullval");
+                add(null, "nullval");
                 assert(length == 3);
-                removeAt(YAMLNull());
+                removeAt(null);
                 assert(length == 2);
             }
         }
@@ -1972,10 +1992,6 @@ struct Node
             }
 
             // Compare validity: if both valid, we have to compare further.
-            const v1 = isValid;
-            const v2 = rhs.isValid;
-            if(!v1){return v2 ? -1 : 0;}
-            if(!v2){return 1;}
 
             const typeCmp = cmp(type, rhs.type);
             if(typeCmp != 0){return typeCmp;}
@@ -2017,25 +2033,25 @@ struct Node
                 case NodeType.null_:
                     return 0;
                 case NodeType.decimal:
-                    const r1 = getValue!real;
-                    const r2 = rhs.getValue!real;
-                    if(isNaN(r1))
+                    const r1 = getValue!double;
+                    const r2 = rhs.getValue!double;
+                    if(r1 != r1)
                     {
-                        return isNaN(r2) ? 0 : -1;
+                        return r2 != r2 ? 0 : -1;
                     }
-                    if(isNaN(r2))
+                    if(r2 != r2)
                     {
                         return 1;
                     }
                     // Fuzzy equality.
-                    if(r1 <= r2 + real.epsilon && r1 >= r2 - real.epsilon)
+                    if(r1 <= r2 + double.epsilon && r1 >= r2 - double.epsilon)
                     {
                         return 0;
                     }
                     return cmp(r1, r2);
                 case NodeType.timestamp:
-                    const t1 = getValue!SysTime;
-                    const t2 = rhs.getValue!SysTime;
+                    const t1 = getValue!Timestamp;
+                    const t2 = rhs.getValue!Timestamp;
                     return cmp(t1, t2);
                 case NodeType.mapping:
                     return compareCollections!(Pair[])(this, rhs);
@@ -2043,8 +2059,6 @@ struct Node
                     return compareCollections!(Node[])(this, rhs);
                 case NodeType.merge:
                     assert(false, "Cannot compare merge nodes");
-                case NodeType.invalid:
-                    assert(false, "Cannot compare invalid nodes");
             }
         }
 
@@ -2081,53 +2095,9 @@ struct Node
         }
 
         /// Get type of the node value.
-        @property NodeType type() const @safe nothrow
+        @property NodeType type() const @safe pure nothrow
         {
-            if (value_.type is typeid(bool))
-            {
-                return NodeType.boolean;
-            }
-            else if (value_.type is typeid(long))
-            {
-                return NodeType.integer;
-            }
-            else if (value_.type is typeid(Node[]))
-            {
-                return NodeType.sequence;
-            }
-            else if (value_.type is typeid(ubyte[]))
-            {
-                return NodeType.binary;
-            }
-            else if (value_.type is typeid(string))
-            {
-                return NodeType.string;
-            }
-            else if (value_.type is typeid(Node.Pair[]))
-            {
-                return NodeType.mapping;
-            }
-            else if (value_.type is typeid(SysTime))
-            {
-                return NodeType.timestamp;
-            }
-            else if (value_.type is typeid(YAMLNull))
-            {
-                return NodeType.null_;
-            }
-            else if (value_.type is typeid(YAMLMerge))
-            {
-                return NodeType.merge;
-            }
-            else if (value_.type is typeid(real))
-            {
-                return NodeType.decimal;
-            }
-            else if (!value_.hasValue)
-            {
-                return NodeType.invalid;
-            }
-            else assert(0, text(value_.type));
+            return value_.kind;
         }
 
         /// Get the kind of node this is.
@@ -2148,8 +2118,6 @@ struct Node
                 case NodeType.merge:
                 case NodeType.decimal:
                     return NodeID.scalar;
-                case NodeType.invalid:
-                    return NodeID.invalid;
             }
         }
     package:
@@ -2210,7 +2178,9 @@ struct Node
         // Determine if the value can be converted to specified type.
         @property bool convertsTo(T)() const
         {
-            if(isType!T){return true;}
+            static if (staticIndexOf!(T, Value.AllowedTypes) >= 0)
+                if (value_._is!T)
+                    return true;
 
             // Every type allowed in Value should be convertible to string.
             static if(isSomeString!T)        {return true;}
@@ -2226,14 +2196,14 @@ struct Node
         */
         void setStyle(CollectionStyle style) @safe
         {
-            enforce(!isValid || (nodeID.among(NodeID.mapping, NodeID.sequence)), new NodeException(
+            enforce(nodeID.among(NodeID.mapping, NodeID.sequence), new NodeException(
                 "Cannot set collection style for non-collection nodes", startMark_));
             collectionStyle = style;
         }
         /// Ditto
         void setStyle(ScalarStyle style) @safe
         {
-            enforce(!isValid || (nodeID == NodeID.scalar), new NodeException(
+            enforce(nodeID == NodeID.scalar, new NodeException(
                 "Cannot set scalar style for non-scalar nodes", startMark_));
             scalarStyle = style;
         }
@@ -2319,14 +2289,16 @@ struct Node
             }
         }
 
-    private:
-        // Determine if the value stored by the node is of specified type.
-        //
-        // This only works for default YAML types, not for user defined types.
-        @property bool isType(T)() const
+        /++
+        Determine if the value stored by the node is of specified type.
+        This only works for default YAML types, not for user defined types.
+        +/
+        @property bool _is(T)() const
         {
-            return value_.type is typeid(Unqual!T);
+            return value_._is!T;
         }
+
+    private:
 
         // Implementation of contains() and containsKey().
         bool contains_(T, Flag!"key" key, string func)(T rhs) const
@@ -2412,12 +2384,15 @@ struct Node
                 static if(key){node = &pair.key;}
                 else          {node = &pair.value;}
 
-
-                const bool typeMatch = (isFloatingPoint!T && (node.type.among!(NodeType.integer, NodeType.decimal))) ||
-                                 (isIntegral!T && node.type == NodeType.integer) ||
-                                 (is(Unqual!T==bool) && node.type == NodeType.boolean) ||
-                                 (isSomeString!T && node.type == NodeType.string) ||
-                                 (node.isType!T);
+                static if (staticIndexOf!(T, Value.AllowedTypes) >= 0)
+                    const isT = node._is!T;
+                else
+                    enum isT = false;
+                const bool typeMatch = isFloatingPoint!T && node.type.among!(NodeType.integer, NodeType.decimal) ||
+                                 isIntegral!T && node.type == NodeType.integer ||
+                                 is(Unqual!T==bool) && node.type == NodeType.boolean ||
+                                 isSomeString!T && node.type == NodeType.string ||
+                                 isT;
                 if(typeMatch && *node == index)
                 {
                     return idx;
@@ -2451,14 +2426,15 @@ struct Node
         // Safe wrapper for coercing a value out of the variant.
         inout(T) coerceValue(T)() @trusted inout
         {
-            return (cast(Value)value_).coerce!T;
+            import mir.conv: to;
+            return value_.tryVisit!(to!T);
         }
         // Safe wrapper for setting a value for the variant.
         void setValue(T)(T value) @trusted
         {
             static if (allowed!T)
             {
-                value_ = value;
+                value_ = Value(value);
             }
             else
             {
@@ -2467,6 +2443,174 @@ struct Node
                 scalarStyle = tmpNode.scalarStyle;
                 collectionStyle = tmpNode.collectionStyle;
                 value_ = tmpNode.value_;
+            }
+        }
+
+        /// Serialization support for mir-ion and asdf
+        public void serialize(S)(ref S serializer) const @safe
+        {
+            value_.visit!(
+                (YAMLNull v) {
+                    serializer.putValue(null);
+                },
+                (YAMLMerge v) {
+                    serializer.putValue("tag:yaml.org,2002:merge");
+                },
+                (bool v) {
+                    serializer.putValue(v);
+                },
+                (long v) {
+                    serializer.putValue(v);
+                },
+                (double v) {
+                    serializer.putValue(v);
+                },
+                (const(ubyte)[] v) {
+                    import mir.lob: Blob;
+                    serializer.putValue(Blob(v));
+                },
+                (Timestamp v) {
+                    serializer.putValue(v);
+                },
+                (string v) {
+                    serializer.putValue(v);
+                },
+                (const(Node.Pair)[] v) {
+                    auto state = serializer.structBegin(v.length);
+                    foreach (ref e; v)
+                    {
+                        serializer.putKey(e.key.get!string);
+                        e.value.serialize(serializer);
+                    }
+                    serializer.structEnd(state);
+                },
+                (const(Node)[] v) {
+                    auto state = serializer.listBegin(v.length);
+                    foreach (ref e; v)
+                    {
+                        serializer.elemBegin;
+                        e.serialize(serializer);
+                    }
+                    serializer.listEnd(state);
+                },
+            );
+        }
+
+        /// Deserialization support for mir-ion
+        public auto deserializeFromIon(IonDescribedValue)(scope const(char[])[] symbolTable, IonDescribedValue value) @trusted {
+            import mir.ndslice.topology: map;
+            import mir.array.allocation: array;
+            return deserializeFromIon(symbolTable.map!idup.array, value);
+        }
+
+        /// ditto
+        public auto deserializeFromIon(IonDescribedValue)(const(string)[] symbolTable, IonDescribedValue value) @trusted {
+            import mir.ion.exception;
+            import mir.ion.type_code;
+            import mir.ion.value;
+            import mir.lob;
+            import mir.timestamp;
+
+            if (value == null) {
+                // Ion has typed null values
+                value_ = YAMLNull.init;
+                return null;
+            }
+
+            final switch (value.descriptor.type) {
+
+                case IonTypeCode.null_:
+                    assert(0); // handled above
+                case IonTypeCode.bool_:
+                    value_ = value.trustedGet!bool;
+                    return null;
+                case IonTypeCode.uInt:
+                case IonTypeCode.nInt:
+                    value_ = value.trustedGet!IonInt.get!long;
+                    return null;
+                case IonTypeCode.float_:
+                    value_ = value.trustedGet!IonFloat.get!double;
+                    return null;
+                case IonTypeCode.decimal:
+                    value_ = value.trustedGet!IonDecimal.get!double;
+                    return null;
+                case IonTypeCode.timestamp:
+                    value_ = value.trustedGet!IonTimestamp.get!Timestamp;
+                    return null;
+                case IonTypeCode.symbol: {
+                    auto symbolId = value.trustedGet!IonSymbolID.get;
+                    if (symbolId >= symbolTable.length)
+                        return IonErrorCode.symbolIdIsTooLargeForTheCurrentSymbolTable.ionException;
+                    value_ = symbolTable[symbolId];
+                    return null;
+                }
+                case IonTypeCode.string:
+                    value_ = value.trustedGet!(const(char)[]).idup;
+                    return null;
+                case IonTypeCode.clob:
+                    throw new IonException("Mir Ion: CLOBs aren't supported in DYAML");
+                case IonTypeCode.blob: // as ubyte[]
+                    value_ = value.trustedGet!Blob.data.dup;
+                    return null;
+                case IonTypeCode.list: {
+                    auto list = value.trustedGet!IonList;
+                    auto ret = new Node[list.walkLength];
+                    size_t i;
+                    foreach (IonDescribedValue elem; list) {
+                        Node val;
+                        if (auto exc = val.deserializeFromIon(symbolTable, elem))
+                            return exc;
+                        ret[i++] = val;
+                    }
+                    value_ = ret;
+                    return null;
+                }
+                case IonTypeCode.sexp: {
+                    // TODO: use special types for SEXP if needed.
+                    auto sexp = value.trustedGet!IonSexp;
+                    auto ret = new Node[sexp.walkLength];
+                    size_t i;
+                    foreach (IonDescribedValue elem; sexp) {
+                        Node val;
+                        if (auto exc = val.deserializeFromIon(symbolTable, elem))
+                            return exc;
+                        ret[i++] = val;
+                    }
+                    value_ = ret;
+                    return null;
+                }
+                case IonTypeCode.struct_: {
+                    auto obj = value.trustedGet!IonStruct;
+                    auto ret = new Pair[obj.walkLength];
+                    size_t i;
+                    foreach (size_t symbolId, IonDescribedValue elem; obj) {
+                        if (symbolId >= symbolTable.length)
+                            return IonErrorCode.symbolIdIsTooLargeForTheCurrentSymbolTable.ionException;
+                        auto key = symbolTable[symbolId];
+                        Node val;
+                        if (auto exc = val.deserializeFromIon(symbolTable, elem))
+                            return exc;
+                        ret[i++] = Pair(key, val);
+                    }
+                    value_ = ret;
+                    return null;
+                }
+                case IonTypeCode.annotations: {
+                    IonAnnotations annotations;
+                    value.trustedGet!IonAnnotationWrapper.unwrap(annotations, value);
+                    Node[] annotationValues;
+                    annotationValues.reserve(1);
+                    foreach (size_t symbolId; annotations) {
+                        if (symbolId >= symbolTable.length)
+                            return IonErrorCode.symbolIdIsTooLargeForTheCurrentSymbolTable.ionException;
+                        annotationValues ~= symbolTable[symbolId].Node;
+                    }
+                    Node val;
+                    if (auto exc = val.deserializeFromIon(symbolTable, value))
+                        return exc;
+                    value_ = [Pair(Node(annotationValues), val)];
+                    return null;
+                }
             }
         }
 }

--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -97,6 +97,9 @@ struct Node
 {
     import std.meta: staticIndexOf;
     import mir.algebraic: TaggedVariant, visit, tryVisit, optionalVisit;
+    import mir.serde: serdeIgnore;
+
+    @serdeIgnore:
     public:
         alias Pair = .Pair;
 

--- a/source/dyaml/reader.d
+++ b/source/dyaml/reader.d
@@ -901,6 +901,5 @@ void test1Byte(R)()
     import dyaml.loader : Loader;
     auto yaml = "hello ";
     auto root = Loader.fromString(yaml).load();
-
-    assert(root.isValid);
+    assert(root._is!string);
 }

--- a/source/dyaml/test/constructor.d
+++ b/source/dyaml/test/constructor.d
@@ -10,12 +10,11 @@ module dyaml.test.constructor;
 version(unittest)
 {
 
+import mir.timestamp;
 import std.conv;
-import std.datetime;
 import std.exception;
 import std.path;
 import std.string;
-import std.typecons;
 
 import dyaml : Loader, Node, YAMLNull;
 
@@ -198,11 +197,11 @@ Node[] constructFloat() @safe
                 ),
                 pair(
                     Node("negative infinity", "tag:yaml.org,2002:str"),
-                    Node(-real.infinity, "tag:yaml.org,2002:float")
+                    Node(-double.infinity, "tag:yaml.org,2002:float")
                 ),
                 pair(
                     Node("not a number", "tag:yaml.org,2002:str"),
-                    Node(real.nan, "tag:yaml.org,2002:float")
+                    Node(double.nan, "tag:yaml.org,2002:float")
                 )
             ],
         "tag:yaml.org,2002:map")
@@ -424,23 +423,23 @@ Node[] constructMerge() @safe
 Node[] constructNull() @safe
 {
     return [
-        Node(YAMLNull(), "tag:yaml.org,2002:null"),
+        Node(null, "tag:yaml.org,2002:null"),
         Node(
             [
                 pair(
                     Node("empty", "tag:yaml.org,2002:str"),
-                    Node(YAMLNull(), "tag:yaml.org,2002:null")
+                    Node(null, "tag:yaml.org,2002:null")
                 ),
                 pair(
                     Node("canonical", "tag:yaml.org,2002:str"),
-                    Node(YAMLNull(), "tag:yaml.org,2002:null")
+                    Node(null, "tag:yaml.org,2002:null")
                 ),
                 pair(
                     Node("english", "tag:yaml.org,2002:str"),
-                    Node(YAMLNull(), "tag:yaml.org,2002:null")
+                    Node(null, "tag:yaml.org,2002:null")
                 ),
                 pair(
-                    Node(YAMLNull(), "tag:yaml.org,2002:null"),
+                    Node(null, "tag:yaml.org,2002:null"),
                     Node("null key", "tag:yaml.org,2002:str")
                 )
             ],
@@ -451,11 +450,11 @@ Node[] constructNull() @safe
                     Node("sparse", "tag:yaml.org,2002:str"),
                     Node(
                         [
-                            Node(YAMLNull(), "tag:yaml.org,2002:null"),
+                            Node(null, "tag:yaml.org,2002:null"),
                             Node("2nd entry", "tag:yaml.org,2002:str"),
-                            Node(YAMLNull(), "tag:yaml.org,2002:null"),
+                            Node(null, "tag:yaml.org,2002:null"),
                             Node("4th entry", "tag:yaml.org,2002:str"),
-                            Node(YAMLNull(), "tag:yaml.org,2002:null")
+                            Node(null, "tag:yaml.org,2002:null")
                         ],
                     "tag:yaml.org,2002:seq")
                 )
@@ -638,6 +637,12 @@ Node[] constructStrUTF8() @safe
     ];
 }
 
+// canonical:        2001-12-15T02:59:43.1Z
+// valid iso8601:    2001-12-14t21:59:43.1-05:00
+// space separated:  2001-12-14 21:59:43.1 -5
+// no time zone (Z): 2001-12-15 2:59:43.1
+// date (00:00:00Z): 2002-12-14
+
 Node[] constructTimestamp() @safe
 {
     return [
@@ -645,23 +650,23 @@ Node[] constructTimestamp() @safe
             [
                 pair(
                     Node("canonical", "tag:yaml.org,2002:str"),
-                    Node(SysTime(DateTime(2001, 12, 15, 2, 59, 43), 1000000.dur!"hnsecs", UTC()), "tag:yaml.org,2002:timestamp")
+                    Node(Timestamp(2001, 12, 15, 2, 59, 43, -1, 1), "tag:yaml.org,2002:timestamp")
                 ),
                 pair(
                     Node("valid iso8601", "tag:yaml.org,2002:str"),
-                    Node(SysTime(DateTime(2001, 12, 15, 2, 59, 43), 1000000.dur!"hnsecs", UTC()), "tag:yaml.org,2002:timestamp")
+                    Node(Timestamp(2001, 12, 15, 2, 59, 43, -1, 1).withOffset(-300), "tag:yaml.org,2002:timestamp")
                 ),
                 pair(
                     Node("space separated", "tag:yaml.org,2002:str"),
-                    Node(SysTime(DateTime(2001, 12, 15, 2, 59, 43), 1000000.dur!"hnsecs", UTC()), "tag:yaml.org,2002:timestamp")
+                    Node(Timestamp(2001, 12, 15, 2, 59, 43, -1, 1).withOffset(-300), "tag:yaml.org,2002:timestamp")
                 ),
                 pair(
                     Node("no time zone (Z)", "tag:yaml.org,2002:str"),
-                    Node(SysTime(DateTime(2001, 12, 15, 2, 59, 43), 1000000.dur!"hnsecs", UTC()), "tag:yaml.org,2002:timestamp")
+                    Node(Timestamp(2001, 12, 15, 2, 59, 43, -1, 1), "tag:yaml.org,2002:timestamp")
                 ),
                 pair(
                     Node("date (00:00:00Z)", "tag:yaml.org,2002:str"),
-                    Node(SysTime(DateTime(2002, 12, 14), UTC()), "tag:yaml.org,2002:timestamp")
+                    Node(Timestamp(2002, 12, 14), "tag:yaml.org,2002:timestamp")
                 )
             ],
         "tag:yaml.org,2002:map")
@@ -762,15 +767,15 @@ Node[] floatRepresenterBug() @safe
                     Node(1L, "tag:yaml.org,2002:int")
                 ),
                 pair(
-                    Node(real.infinity, "tag:yaml.org,2002:float"),
+                    Node(double.infinity, "tag:yaml.org,2002:float"),
                     Node(10L, "tag:yaml.org,2002:int")
                 ),
                 pair(
-                    Node(-real.infinity, "tag:yaml.org,2002:float"),
+                    Node(-double.infinity, "tag:yaml.org,2002:float"),
                     Node(-10L, "tag:yaml.org,2002:int")
                 ),
                 pair(
-                    Node(real.nan, "tag:yaml.org,2002:float"),
+                    Node(double.nan, "tag:yaml.org,2002:float"),
                     Node(100L, "tag:yaml.org,2002:int")
                 )
             ],
@@ -798,10 +803,10 @@ Node[] moreFloats() @safe
                 Node(0.0L, "tag:yaml.org,2002:float"),
                 Node(1.0L, "tag:yaml.org,2002:float"),
                 Node(-1.0L, "tag:yaml.org,2002:float"),
-                Node(real.infinity, "tag:yaml.org,2002:float"),
-                Node(-real.infinity, "tag:yaml.org,2002:float"),
-                Node(real.nan, "tag:yaml.org,2002:float"),
-                Node(real.nan, "tag:yaml.org,2002:float")
+                Node(double.infinity, "tag:yaml.org,2002:float"),
+                Node(-double.infinity, "tag:yaml.org,2002:float"),
+                Node(double.nan, "tag:yaml.org,2002:float"),
+                Node(double.nan, "tag:yaml.org,2002:float")
             ],
         "tag:yaml.org,2002:seq")
     ];
@@ -821,17 +826,24 @@ Node[] singleDotFloatBug() @safe
     ];
 }
 
+
+
+
+
+
+
+
 Node[] timestampBugs() @safe
 {
     return [
         Node(
             [
-                Node(SysTime(DateTime(2001, 12, 15, 3, 29, 43), 1000000.dur!"hnsecs", UTC()), "tag:yaml.org,2002:timestamp"),
-                Node(SysTime(DateTime(2001, 12, 14, 16, 29, 43), 1000000.dur!"hnsecs", UTC()), "tag:yaml.org,2002:timestamp"),
-                Node(SysTime(DateTime(2001, 12, 14, 21, 59, 43), 10100.dur!"hnsecs", UTC()), "tag:yaml.org,2002:timestamp"),
-                Node(SysTime(DateTime(2001, 12, 14, 21, 59, 43), new immutable SimpleTimeZone(60.dur!"minutes")), "tag:yaml.org,2002:timestamp"),
-                Node(SysTime(DateTime(2001, 12, 14, 21, 59, 43), new immutable SimpleTimeZone(-90.dur!"minutes")), "tag:yaml.org,2002:timestamp"),
-                Node(SysTime(DateTime(2005, 7, 8, 17, 35, 4), 5176000.dur!"hnsecs", UTC()), "tag:yaml.org,2002:timestamp")
+                "2001-12-14T21:59:43.1-05:30".Timestamp.Node("tag:yaml.org,2002:timestamp"),
+                "2001-12-14T21:59:43.1+05:30".Timestamp.Node("tag:yaml.org,2002:timestamp"),
+                "2001-12-14T21:59:43.00101Z".Timestamp.Node("tag:yaml.org,2002:timestamp"),
+                "2001-12-14T21:59:43+01".Timestamp.Node("tag:yaml.org,2002:timestamp"),
+                "2001-12-14T21:59:43-01:30".Timestamp.Node("tag:yaml.org,2002:timestamp"),
+                "2005-07-08T17:35:04.517600Z".Timestamp.Node("tag:yaml.org,2002:timestamp")
             ],
         "tag:yaml.org,2002:seq")
     ];


### PR DESCRIPTION
- replace `real` with `double` to match other implementations: excess precision is bad when one need precise serialisation, fixes #270 
- use mir to/from string for floating point numbers, fixes #249 
- replace SysTime with Timestamp, arbitrary timestamp precision is supported now. For example, one can de/serialise `Date` without additional time. `master` can serialise only full precision timestamps.
- added mir engine de/serialisation support for `Node`
