### PR TITLE
Minor fixes to release v0.8.4

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('D-YAML', 'd',
     meson_version: '>=0.40.0',
     subproject_dir: 'contrib',
-    version: '0.8.0'
+    version: '0.8.4'
 )
 
 project_soversion    = '0'

--- a/source/dyaml/emitter.d
+++ b/source/dyaml/emitter.d
@@ -906,7 +906,7 @@ struct Emitter(Range, CharType) if (isOutputRange!(Range, CharType))
         {
 
             string tagString = tag;
-            if(tagString == "!"){return tagString;}
+            if (tagString == "!") return "!";
             string handle;
             string suffix = tagString;
 

--- a/source/dyaml/representer.d
+++ b/source/dyaml/representer.d
@@ -142,7 +142,7 @@ Node representData(const Node data, ScalarStyle defaultScalarStyle, CollectionSt
 {
     // Float comparison is pretty unreliable...
     auto result = representData(Node(1.0), ScalarStyle.invalid, CollectionStyle.invalid);
-    assert(approxEqual(result.as!string.to!real, 1.0));
+    assert(isClose(result.as!string.to!real, 1.0));
     assert(result.tag == "tag:yaml.org,2002:float");
 
     assert(representData(Node(real.nan), ScalarStyle.invalid, CollectionStyle.invalid) == Node(".nan", "tag:yaml.org,2002:float"));


### PR DESCRIPTION
I'd like to release v0.8.4 so users can get a better view of their errors, thanks to @tom-tan 's improvements.
So I did a pass checking for deprecations (just one), and gave a shot to `dflags: [ "-preview=in", "-preview=dip1000" ]` just in case. Didn't compile but found one easy fix.