### PR TITLE
Convert logo image to svg

### DIFF
--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -23,28 +23,25 @@
      inkscape:pagecheckerboard="false"
      inkscape:document-units="mm"
      showgrid="false"
-     inkscape:zoom="3.1154932"
-     inkscape:cx="92.120247"
-     inkscape:cy="66.602618"
+     inkscape:zoom="3.1090604"
+     inkscape:cx="96.170536"
+     inkscape:cy="-1.7690232"
      inkscape:window-width="1920"
      inkscape:window-height="1037"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer2"
+     inkscape:current-layer="layer3"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
-     fit-margin-bottom="0" />
-  <defs
-     id="defs2">
-    <rect
-       x="66.340093"
-       y="22.056979"
-       width="40.293034"
-       height="63.194422"
-       id="rect19230" />
-  </defs>
+     fit-margin-bottom="0"
+     inkscape:snap-intersection-paths="false"
+     inkscape:object-paths="false"
+     inkscape:snap-smooth-nodes="false"
+     inkscape:snap-others="true"
+     inkscape:snap-text-baseline="false"
+     inkscape:snap-bbox="false" />
   <g
      inkscape:groupmode="layer"
      id="layer3"
@@ -61,60 +58,90 @@
   </g>
   <g
      inkscape:groupmode="layer"
-     id="layer2"
-     inkscape:label="Text"
+     id="layer1"
+     inkscape:label="Redraw"
      style="display:inline">
-    <text
-       xml:space="preserve"
-       transform="matrix(0.40464801,0,0,0.39609019,-10.936262,-5.6226013)"
-       id="text19228"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';white-space:pre;shape-inside:url(#rect19230);fill:#ffaaaa;fill-opacity:1"><tspan
-         x="66.339844"
-         y="57.498603"
-         id="tspan71321">D</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:10.5833px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.264583"
-       x="26.645956"
-       y="15.5801"
-       id="text94042"><tspan
-         sodipodi:role="line"
-         id="tspan94040"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
-         x="26.645956"
-         y="15.5801">:</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:13.7892px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.34473"
-       x="2.9176788"
-       y="15.766471"
-       id="text103504"><tspan
-         sodipodi:role="line"
-         id="tspan103502"
-         style="stroke-width:0.34473"
-         x="2.9176788"
-         y="15.766471">---</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.5734px;line-height:1.25;font-family:'Glacial Indifference';-inkscape-font-specification:'Glacial Indifference, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#faf5f4;fill-opacity:1;stroke-width:0.339338"
-       x="29.272896"
-       y="16.232538"
-       id="text110546"><tspan
-         sodipodi:role="line"
-         id="tspan110544"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.5734px;font-family:'Glacial Indifference';-inkscape-font-specification:'Glacial Indifference, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#faf5f4;fill-opacity:1;stroke-width:0.339338"
-         x="29.272896"
-         y="16.232538">YAML</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:9.9789px;line-height:1.25;font-family:Arial;-inkscape-font-specification:Arial;stroke-width:0.249473"
-       x="61.366016"
-       y="16.014214"
-       id="text114486"><tspan
-         sodipodi:role="line"
-         id="tspan114484"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.9789px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.249473"
-         x="61.366016"
-         y="16.014214">...</tspan></text>
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3.3596127,11.588522 -0.00167,1.215397 h 3.7208859 v -1.216451 z"
+       id="path366" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7.9491328,11.587597 -0.00167,1.215397 h 3.7208852 v -1.216451 z"
+       id="path366-3" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12.542085,11.587383 -0.0017,1.215397 h 3.720885 v -1.216451 z"
+       id="path366-3-6" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#ffaaaa;stroke-width:1.50865;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.208542,6.5772319 0.0019,9.9235361 2.984365,-0.0015 c 2.257131,-0.0011 4.028957,-1.841084 4.028957,-4.960275 0,-3.7743035 -1.988594,-4.95213 -4.148338,-4.95213 z"
+       id="path1429"
+       sodipodi:nodetypes="ccsscc" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.08054;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect33186"
+       width="1.318697"
+       height="1.4490472"
+       x="27.402775"
+       y="9.7524118"
+       ry="0.63109142" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.08054;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect33186-7"
+       width="1.318697"
+       height="1.4490472"
+       x="27.399069"
+       y="14.282472"
+       ry="0.63109142" />
+    <rect
+       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.08054;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect33186-7-5"
+       width="1.2367439"
+       height="1.3484181"
+       x="62.078617"
+       y="14.800523"
+       ry="0.56990385" />
+    <path
+       style="fill:#faf5f4;fill-opacity:1;stroke:#faf5f4;stroke-width:0.0264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 29.435146,7.01655 1.188715,-7.54e-4 2.762109,3.95981 2.761828,-3.9591246 1.176365,-0.00139 -3.476821,4.8699456 5.08e-4,4.333336 -0.923882,0.0017 -3.04e-4,-4.321608 z"
+       id="path33522"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:#faf5f4;fill-opacity:1;stroke:#faf5f4;stroke-width:0.0264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 35.645065,16.219087 1.003538,2.79e-4 0.990773,-2.511287 4.076129,-6e-6 0.990177,2.511131 1.003729,0.0014 -4.025414,-9.821757 z"
+       id="path63310"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:#a02010;fill-opacity:1;stroke:#a02010;stroke-width:0.0264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38.020975,12.826118 3.312824,-1.75e-4 -1.649675,-4.1982801 z"
+       id="path64470"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#faf5f4;fill-opacity:1;stroke:#faf5f4;stroke-width:0.0264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 44.015432,16.21915 0.952875,-2.51e-4 1.430776,-6.6010501 2.785926,7.1215661 2.772621,-7.1217129 1.445932,6.6015999 0.938289,0.0031 -2.13315,-9.7860055 -3.024245,7.8909655 -3.023596,-7.8922607 z"
+       id="path89584"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="fill:#faf5f4;fill-opacity:1;stroke:#faf5f4;stroke-width:0.0264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 55.522331,7.0154589 0.0011,9.2051281 4.221809,-5.08e-4 v -0.92532 l -3.297426,0.0011 -3.04e-4,-8.2790775 z"
+       id="path102819"
+       sodipodi:nodetypes="ccccccc" />
+    <rect
+       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.08054;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect33186-7-5-2"
+       width="1.2367439"
+       height="1.3484181"
+       x="64.755455"
+       y="14.799554"
+       ry="0.56990385" />
+    <rect
+       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.08054;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect33186-7-5-9"
+       width="1.2367439"
+       height="1.3484181"
+       x="67.430305"
+       y="14.800311"
+       ry="0.56990385" />
   </g>
 </svg>


### PR DESCRIPTION
Hi, this PR fixes #167 by providing an svg file for the logo image. I tried to recreate the original logo as precise as I could.

I didn't delete the 2 old bitmap files to be sure to not break anything, but I have not found any place in the repository where it is used, so I can delete them if needed.