### PR TITLE
fix(ci/yaml-test-suite): Update path to yaml-test-suite test cases

### DIFF
--- a/testsuite/source/app.d
+++ b/testsuite/source/app.d
@@ -291,7 +291,7 @@ TestResult runTests(string tml) @safe
 // Can't be @safe due to dirEntries()
 void main(string[] args) @system
 {
-    string path = "yaml-test-suite/test";
+    string path = "yaml-test-suite/src";
 
     void printResult(string id, TestResult result)
     {


### PR DESCRIPTION
A recent [PR][1] to [yaml-test-suite][2] moved the test cases from `test/` to `src/` and broke our CI pipeline.

This commit resolves #276.

[1]: yaml/yaml-test-suite#85
[2]: https://github.com/yaml/yaml-test-suite