### PR TITLE
Add MarkedYAMLException#mark

### DIFF
--- a/source/dyaml/exception.d
+++ b/source/dyaml/exception.d
@@ -94,6 +94,9 @@ struct MarkedYAMLExceptionData
 // Base class of YAML exceptions with marked positions of the problem.
 abstract class MarkedYAMLException : YAMLException
 {
+    /// Position of the error.
+    Mark mark;
+
     // Construct a MarkedYAMLException with specified context and problem.
     this(string context, const Mark contextMark, string problem, const Mark problemMark,
          string file = __FILE__, size_t line = __LINE__) @safe pure nothrow
@@ -119,8 +122,6 @@ abstract class MarkedYAMLException : YAMLException
     {
         with(data) this(context, contextMark, problem, problemMark);
     }
-
-    Mark mark;
 }
 
 // Constructors of YAML exceptions are mostly the same, so we use a mixin.

--- a/source/dyaml/exception.d
+++ b/source/dyaml/exception.d
@@ -102,6 +102,7 @@ abstract class MarkedYAMLException : YAMLException
                     (contextMark != problemMark ? contextMark.toString() ~ '\n' : "") ~
                     problem ~ '\n' ~ problemMark.toString() ~ '\n';
         super(msg, file, line);
+        mark = problemMark;
     }
 
     // Construct a MarkedYAMLException with specified problem.
@@ -110,6 +111,7 @@ abstract class MarkedYAMLException : YAMLException
         @safe pure nothrow
     {
         super(problem ~ '\n' ~ problemMark.toString(), file, line);
+        mark = problemMark;
     }
 
     /// Construct a MarkedYAMLException from a struct storing constructor parameters.
@@ -117,6 +119,8 @@ abstract class MarkedYAMLException : YAMLException
     {
         with(data) this(context, contextMark, problem, problemMark);
     }
+
+    Mark mark;
 }
 
 // Constructors of YAML exceptions are mostly the same, so we use a mixin.


### PR DESCRIPTION
This request adds `MarkedYAMLException#mark`.
It is useful for debugging and also enables users of D-YAML to make fine-grained error messages.