### PR TITLE
Fix Loader#name to show the file name in exception message

### DIFF
--- a/source/dyaml/loader.d
+++ b/source/dyaml/loader.d
@@ -165,6 +165,7 @@ struct Loader
         void name(string name) pure @safe nothrow @nogc
         {
             name_ = name;
+            scanner_.name = name;
         }
 
         /// Specify custom Resolver to use.
@@ -391,4 +392,20 @@ struct Loader
     auto yaml = "{\n\"root\": {\n\t\"key\": \"value\"\n    }\n}";
     auto doc = Loader.fromString(yaml).load();
     assert(doc.isValid);
+}
+
+@safe unittest
+{
+    import std.exception : collectException;
+
+    auto yaml = q"EOS
+    value: invalid: string
+EOS";
+    auto filename = "invalid.yml";
+    auto loader = Loader.fromString(yaml);
+    loader.name = filename;
+
+    Node unused;
+    auto e = loader.load().collectException!ScannerException(unused);
+    assert(e.mark.name == filename);
 }

--- a/source/dyaml/reader.d
+++ b/source/dyaml/reader.d
@@ -405,6 +405,9 @@ final class Reader
         /// Get file name.
         string name() const @safe pure nothrow @nogc { return name_; }
 
+        /// Set file name.
+        void name(string name) pure @safe nothrow @nogc { name_ = name; }
+
         /// Get current line number.
         uint line() const @safe pure nothrow @nogc { return line_; }
 

--- a/source/dyaml/scanner.d
+++ b/source/dyaml/scanner.d
@@ -185,6 +185,12 @@ struct Scanner
             return tokens_.empty;
         }
 
+        /// Set file name.
+        void name(string name) @safe pure nothrow @nogc
+        {
+            reader_.name = name;
+        }
+
     private:
         /// Most scanning error messages have the same format; so build them with this
         /// function.


### PR DESCRIPTION
This request fixes `Loader#name` to propagate the file name to its `reader_` field to show the file name in the exception messages.

Here is an example:
```dlang
@safe unittest
{
    import std.exception : collectException;

    auto yaml = q"EOS
    value: invalid: string
EOS";
    auto filename = "invalid.yml";
    auto loader = Loader.fromString(yaml);
    loader.name = filename;

    Node unused;
    auto e = loader.load().collectException!ScannerException(unused);
    assert(e.mark.name == filename); // expect "invalid.yml"
}
```

Before merging this request:

```console
$ dub test
...
Running ./dyaml-test-library 
source/dyaml/loader.d(410): [unittest] Assertion failure
core.exception.AssertError@source/dyaml/loader.d(410): Assertion failure
...
1/19 modules FAILED unittests
Program exited with code 1
```

It fails because `e.mark.name` is `"<unknown>"`.

After merging this request:
```console
$  dub test
...
19 modules passed unittests
```