### PR TITLE
Don't output !!str tags except when doing canonical output (fixes #253)

### DIFF
--- a/source/dyaml/dumper.d
+++ b/source/dyaml/dumper.d
@@ -228,7 +228,7 @@ struct Dumper
     dumper.explicitStart = false;
     dumper.YAMLVersion = null;
     dumper.dump(stream, node);
-    assert(stream.data == "[!!str 'Hello world!', [!!str 'Hello', !!str 'world!']]\n");
+    assert(stream.data == "['Hello world!', ['Hello', 'world!']]\n");
 }
 // Explicit document start/end markers
 @safe unittest
@@ -244,6 +244,17 @@ struct Dumper
     assert(stream.data[0..3] == "---");
     //account for newline at end
     assert(stream.data[$-4..$-1] == "...");
+}
+@safe unittest
+{
+    auto stream = new Appender!string();
+    auto node = Node([Node("Te, st2")]);
+    auto dumper = dumper();
+    dumper.explicitStart = true;
+    dumper.explicitEnd = false;
+    dumper.YAMLVersion = null;
+    dumper.dump(stream, node);
+    assert(stream.data == "--- ['Te, st2']\n");
 }
 // No explicit document start/end markers
 @safe unittest

--- a/source/dyaml/emitter.d
+++ b/source/dyaml/emitter.d
@@ -774,7 +774,7 @@ struct Emitter(Range, CharType) if (isOutputRange!(Range, CharType))
             {
                 if(style_ == ScalarStyle.invalid){style_ = chooseScalarStyle();}
                 if((!canonical_ || (tag is null)) &&
-                   (style_ == ScalarStyle.plain ? event_.implicit : !event_.implicit && (tag is null)))
+                   ((tag == "tag:yaml.org,2002:str") || (style_ == ScalarStyle.plain ? event_.implicit : !event_.implicit && (tag is null))))
                 {
                     preparedTag_ = null;
                     return;


### PR DESCRIPTION
This may need refinement for the case where the user wishes to explicitly output string tags, but that's rarely desirable outside of canonical output, which still works