### PR TITLE
Fix usage of `dumper` and `dump` in the documents

### DIFF
--- a/docs/tutorials/custom_types.md
+++ b/docs/tutorials/custom_types.md
@@ -236,13 +236,13 @@ void main()
 {
     try
     {
-        auto dumper = dumper(File("output.yaml", "w").lockingTextWriter);
+        auto dumper = dumper();
 
         auto document = Node([Color(255, 0, 0),
                               Color(0, 255, 0),
                               Color(0, 0, 255)]);
 
-        dumper.dump(document);
+        dumper.dump(File("output.yaml", "w").lockingTextWriter, document);
     }
     catch(YAMLException e)
     {

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -100,7 +100,7 @@ will try to convert it, throwing *YAMLException* if not possible.
 
 Finally we dump the document we just read to `output.yaml` with the
 *Dumper.dump()* method. *Dumper* is a struct used to dump YAML
-documents. *dumper()* returns a *Dumpper* with the default setting.
+documents. *dumper()* returns a *Dumper* with the default setting.
 The *dump()* method writes one or more documents to a range,
 throwing *YAMLException* if it could not be written to.
 

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -58,7 +58,7 @@ void main()
     writeln("The answer is ", root["Answer"].as!int);
 
     //Dump the loaded document to output.yaml.
-    dumper(File("output.yaml", "w").lockingTextWriter).dump(root);
+    dumper.dump(File("output.yaml", "w").lockingTextWriter, root);
 }
 ```
 
@@ -100,8 +100,8 @@ will try to convert it, throwing *YAMLException* if not possible.
 
 Finally we dump the document we just read to `output.yaml` with the
 *Dumper.dump()* method. *Dumper* is a struct used to dump YAML
-documents. *dumper()* accepts a range to write the document to.
-The *dump()* method writes one or more documents to the range,
+documents. *dumper()* returns a *Dumpper* with the default setting.
+The *dump()* method writes one or more documents to a range,
 throwing *YAMLException* if it could not be written to.
 
 D:YAML tries to preserve style information in documents so e.g. `[Hello,


### PR DESCRIPTION
Current documents uses `dumper` function that takes an output range but the latest version of D-YAML (v0.8.5) only provides `dumper` with no arguments (See https://dyaml.dpldocs.info/v0.8.5/dyaml.dumper.dumper.html).

This request fixes `getting_started.md` and `custom_types.md` to use the latest interface of `dumper` and `Dumper.dump`.