### PR TITLE
Fix switch case fallthrough

### DIFF
--- a/source/dyaml/representer.d
+++ b/source/dyaml/representer.d
@@ -91,6 +91,7 @@ Node representData(const Node data, ScalarStyle defaultScalarStyle, CollectionSt
             {
                 result.collectionStyle = defaultCollectionStyle;
             }
+            break;
         case NodeID.invalid:
     }
 


### PR DESCRIPTION
Since `case NodeID.invalid:` has no code this is not problematic yet, but needed for https://github.com/dlang/dmd/pull/13972