### PR TITLE
Make `MarkedYAMLException` and `ParserException` public

### DIFF
--- a/source/dyaml/exception.d
+++ b/source/dyaml/exception.d
@@ -77,20 +77,6 @@ struct Mark
         }
 }
 
-package:
-// A struct storing parameters to the MarkedYAMLException constructor.
-struct MarkedYAMLExceptionData
-{
-    // Context of the error.
-    string context;
-    // Position of the context in a YAML buffer.
-    Mark contextMark;
-    // The error itself.
-    string problem;
-    // Position if the error.
-    Mark problemMark;
-}
-
 // Base class of YAML exceptions with marked positions of the problem.
 abstract class MarkedYAMLException : YAMLException
 {
@@ -122,6 +108,20 @@ abstract class MarkedYAMLException : YAMLException
     {
         with(data) this(context, contextMark, problem, problemMark);
     }
+}
+
+package:
+// A struct storing parameters to the MarkedYAMLException constructor.
+struct MarkedYAMLExceptionData
+{
+    // Context of the error.
+    string context;
+    // Position of the context in a YAML buffer.
+    Mark contextMark;
+    // The error itself.
+    string problem;
+    // Position if the error.
+    Mark problemMark;
 }
 
 // Constructors of YAML exceptions are mostly the same, so we use a mixin.

--- a/source/dyaml/parser.d
+++ b/source/dyaml/parser.d
@@ -25,7 +25,6 @@ import dyaml.token;
 import dyaml.tagdirective;
 
 
-package:
 /**
  * The following YAML grammar is LL(1) and is parsed by a recursive descent
  * parser.
@@ -99,6 +98,7 @@ class ParserException : MarkedYAMLException
     mixin MarkedExceptionCtors;
 }
 
+package:
 /// Generates events from tokens provided by a Scanner.
 ///
 /// While Parser receives tokens with non-const character slices, the events it


### PR DESCRIPTION
It makes users to catch and handle specific type of exceptions.