### PR TITLE
add an explicit break to silence a deprecation

### DIFF
--- a/source/dyaml/representer.d
+++ b/source/dyaml/representer.d
@@ -93,6 +93,7 @@ Node representData(const Node data, ScalarStyle defaultScalarStyle, CollectionSt
             }
             break;
         case NodeID.invalid:
+            break;
     }
 
 


### PR DESCRIPTION
Fixes a deprecation introduced by DMD 2.100.0.