### PR TITLE
constructor: Use new RedblackTree instead of redBlackTree function

### DIFF
--- a/source/dyaml/constructor.d
+++ b/source/dyaml/constructor.d
@@ -481,7 +481,7 @@ Node.Pair[] constructOrderedMap(const Node[] nodes) @safe
 
     //Detect duplicates.
     //TODO this should be replaced by something with deterministic memory allocation.
-    auto keys = redBlackTree!Node();
+    auto keys = new RedBlackTree!Node();
     foreach(ref pair; pairs)
     {
         enforce(!(pair.key in keys),
@@ -600,7 +600,7 @@ Node.Pair[] constructMap(Node.Pair[] pairs) @safe
 {
     //Detect duplicates.
     //TODO this should be replaced by something with deterministic memory allocation.
-    auto keys = redBlackTree!Node();
+    auto keys = new RedBlackTree!Node();
     foreach(ref pair; pairs)
     {
         enforce(!(pair.key in keys),


### PR DESCRIPTION
The latter takes a scope array, meaning it is inferred as system under DIP1000.