### PR TITLE
[Blocked] Make sure disabled functions have correct signature

### DIFF
--- a/source/dyaml/dumper.d
+++ b/source/dyaml/dumper.d
@@ -73,8 +73,8 @@ struct Dumper
         // Default style for collection nodes. If style is $(D CollectionStyle.invalid), the _style is chosen automatically.
         CollectionStyle defaultCollectionStyle = CollectionStyle.invalid;
 
-        @disable bool opEquals(ref Dumper);
-        @disable int opCmp(ref Dumper);
+        @disable bool opEquals(ref const Dumper) const scope @safe pure nothrow @nogc;
+        @disable int opCmp(ref const Dumper) const scope @safe pure nothrow @nogc;
 
         ///Set indentation width. 2 by default. Must not be zero.
         @property void indent(uint indent) pure @safe nothrow

--- a/source/dyaml/emitter.d
+++ b/source/dyaml/emitter.d
@@ -152,8 +152,8 @@ struct Emitter(Range, CharType) if (isOutputRange!(Range, CharType))
         ScalarStyle style_ = ScalarStyle.invalid;
 
     public:
-        @disable int opCmp(ref Emitter);
-        @disable bool opEquals(ref Emitter);
+        @disable int opCmp(ref const Emitter) const scope @safe pure nothrow @nogc;
+        @disable bool opEquals(ref const Emitter) const scope @safe pure nothrow @nogc;
 
         /**
          * Construct an emitter.

--- a/source/dyaml/loader.d
+++ b/source/dyaml/loader.d
@@ -49,9 +49,10 @@ struct Loader
         bool rangeInitialized;
 
     public:
-        @disable this();
-        @disable int opCmp(ref Loader);
-        @disable bool opEquals(ref Loader);
+        @disable this() @safe pure nothrow @nogc;
+        @disable this() const @safe pure nothrow @nogc;
+        @disable int opCmp(ref const Loader) const scope @safe pure nothrow @nogc;
+        @disable bool opEquals(ref const Loader) const scope @safe pure nothrow @nogc;
 
         /** Construct a Loader to load YAML from a file.
          *

--- a/source/dyaml/resolver.d
+++ b/source/dyaml/resolver.d
@@ -100,8 +100,8 @@ struct Resolver
         }
 
     public:
-        @disable bool opEquals(ref Resolver);
-        @disable int opCmp(ref Resolver);
+        @disable bool opEquals(ref const Resolver) const scope @safe pure nothrow @nogc;
+        @disable int opCmp(ref const Resolver) const scope @safe pure nothrow @nogc;
 
         /**
          * Add an implicit scalar resolver.


### PR DESCRIPTION
```
One of the issues with disable at the moment is that it does
'regular' overload resolution, so trying to e.g. compare
const objects will fail because the overload is not marked const.
This has subtle consequences, for example on how typeinfos are generated.
```

While working on DIP1000 compatibility I came across this issue. It revealed [a bug](https://github.com/dlang/dmd/pull/14272) in the frontend, which will be fixed in v2.101.0, so we can't merge this PR for a while.