### PR TITLE
Fix #302: Support escaped forward slashes

### DIFF
--- a/source/dyaml/escapes.d
+++ b/source/dyaml/escapes.d
@@ -11,7 +11,7 @@ package:
 
 import std.meta : AliasSeq;
 alias escapes = AliasSeq!('0', 'a', 'b', 't', '\t', 'n', 'v', 'f', 'r', 'e', ' ',
-                             '\"', '\\', 'N', '_', 'L', 'P');
+                          '/', '\"', '\\', 'N', '_', 'L', 'P');
 
 /// YAML hex codes specifying the length of the hex number.
 alias escapeHexCodeList = AliasSeq!('x', 'u', 'U');
@@ -31,6 +31,7 @@ dchar fromEscape(dchar escape) @safe pure nothrow @nogc
         case 'f':  return '\x0C';
         case 'r':  return '\x0D';
         case 'e':  return '\x1B';
+        case '/':  return '/';
         case ' ':  return '\x20';
         case '\"': return '\"';
         case '\\': return '\\';
@@ -90,3 +91,16 @@ uint escapeHexLength(dchar hexCode) @safe pure nothrow @nogc
     }
 }
 
+// Issue #302: Support optional escaping of forward slashes in string
+// for JSON compatibility
+@safe unittest
+{
+    import dyaml.loader : Loader;
+
+    const str = `{
+    "forward/slashes": "can\/be\/optionally\/escaped"
+}`;
+
+    auto node = Loader.fromString(str).load();
+    assert(node["forward/slashes"] == "can/be/optionally/escaped");
+}


### PR DESCRIPTION
This provides better compatibility with JSON, and is what Vibe.d does by default:
https://github.com/vibe-d/vibe.d/blob/7604eea772b1a733f7bfd16591ddc5bd37850bd9/data/vibe/data/json.d#L2555-L2563