### PR TITLE
add .pdb files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /examples/getting_started/main.obj
 /cdc.obj
 /unittest
+*.pdb
 
 # Backups #
 ###########


### PR DESCRIPTION
Dub leaves them outside of the .dub folder now, and they should never be committed.