### PR TITLE
correct an assert() in Scanner.fetchValue, have it occur earlier

### DIFF
--- a/source/dyaml/scanner.d
+++ b/source/dyaml/scanner.d
@@ -540,11 +540,11 @@ struct Scanner
                !possibleSimpleKeys_[flowLevel_].isNull)
             {
                 const key = possibleSimpleKeys_[flowLevel_];
+                assert(key.tokenIndex >= tokensTaken_);
+
                 possibleSimpleKeys_[flowLevel_].isNull = true;
                 Mark keyMark = key.mark;
                 const idx = key.tokenIndex - tokensTaken_;
-
-                assert(idx >= 0);
 
                 // Add KEY.
                 // Manually inserting since tokens are immutable (need linked list).


### PR DESCRIPTION
Related to #325, but not a solution for it. idx was unsigned, so it could never be less than 0.