### PR TITLE
Fix a DMD 2.109.0 deprecation

### DIFF
--- a/source/dyaml/event.d
+++ b/source/dyaml/event.d
@@ -68,17 +68,14 @@ struct Event
     EventID id = EventID.invalid;
     ///Style of scalar event, if this is a scalar event.
     ScalarStyle scalarStyle = ScalarStyle.invalid;
-    union
-    {
-        ///Should the tag be implicitly resolved?
-        bool implicit;
-        /**
-         * Is this document event explicit?
-         *
-         * Used if this is a DocumentStart or DocumentEnd.
-         */
-        bool explicitDocument;
-    }
+    ///Should the tag be implicitly resolved?
+    bool implicit;
+    /**
+     * Is this document event explicit?
+     *
+     * Used if this is a DocumentStart or DocumentEnd.
+     */
+    alias explicitDocument = implicit;
     ///Collection style, if this is a SequenceStart or MappingStart.
     CollectionStyle collectionStyle = CollectionStyle.invalid;
 


### PR DESCRIPTION
It's odd that a bool+bool union could possibly have unsafe bit patterns, but this is a very trivial and clean fix