### PR TITLE
remove removed stdsumtype.d from meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,8 +40,7 @@ dyaml_src = [
     'source/dyaml/test/representer.d',
     'source/dyaml/test/suite.d',
     'source/dyaml/test/suitehelpers.d',
-    'source/dyaml/token.d',
-    'source/dyaml/stdsumtype.d'
+    'source/dyaml/token.d'
 ]
 install_subdir('source/dyaml', install_dir: 'include/d/yaml/')
 


### PR DESCRIPTION
Followup to #330. Really should have reran the test suite, I guess.