### PR TITLE
support wider Marks (off by default)

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -10,6 +10,10 @@
     "copyright": "Copyright © 2011-2018, Ferdinand Majerech",
     "configurations": [
         { "name": "library"  },
+        {
+            "name": "widemark",
+            "versions": ["widemark"]
+         },
         { "name": "unittest" },
         {
             "name": "unittest-dip1000",

--- a/source/dyaml/exception.d
+++ b/source/dyaml/exception.d
@@ -23,35 +23,43 @@ class YAMLException : Exception
     mixin basicExceptionCtors;
 }
 
+version(widemark)
+{
+    package alias MarkPosition = uint;
+}
+else
+{
+    package alias MarkPosition = ushort;
+}
 /// Position in a YAML stream, used for error messages.
 struct Mark
 {
     /// File name.
     string name = "<unknown>";
     /// Line number.
-    ushort line;
+    MarkPosition line;
     /// Column number.
-    ushort column;
+    MarkPosition column;
 
     public:
         /// Construct a Mark with specified line and column in the file.
         this(string name, const uint line, const uint column) @safe pure nothrow @nogc
         {
             this.name = name;
-            this.line = cast(ushort)min(ushort.max, line);
+            this.line = cast(MarkPosition)min(MarkPosition.max, line);
             // This *will* overflow on extremely wide files but saves CPU time
             // (mark ctor takes ~5% of time)
-            this.column = cast(ushort)column;
+            this.column = cast(MarkPosition)column;
         }
 
         /// Get a string representation of the mark.
         void toString(W)(ref W writer) const scope
         {
             // Line/column numbers start at zero internally, make them start at 1.
-            void writeClamped(ushort v)
+            void writeClamped(MarkPosition v)
             {
                 writer.formattedWrite!"%s"(v + 1);
-                if (v == ushort.max)
+                if (v == MarkPosition.max)
                 {
                     put(writer, "or higher");
                 }

--- a/source/dyaml/test/suite.d
+++ b/source/dyaml/test/suite.d
@@ -146,11 +146,11 @@ TestResult runTest(string name, Node doc) @safe
             }
             if ("line" in *node)
             {
-                mark.line = cast(ushort)((*node)["line"].as!ushort - 1);
+                mark.line = cast(MarkPosition)((*node)["line"].as!MarkPosition - 1);
             }
             if ("column" in *node)
             {
-                mark.column = cast(ushort)((*node)["column"].as!ushort - 1);
+                mark.column = cast(MarkPosition)((*node)["column"].as!MarkPosition - 1);
             }
             return Nullable!Mark(mark);
         }


### PR DESCRIPTION
While I would love to enable this by default, the number of instances of these structs means a rather substantial increase to memory usage.